### PR TITLE
Add MVSECDataLoader with persistent sidecar caching and event backends

### DIFF
--- a/src/evlib/dataloaders/__init__.py
+++ b/src/evlib/dataloaders/__init__.py
@@ -3,10 +3,12 @@
 from ._base import DataLoaderBase
 from ._mvsec import MVSECDataLoader
 from ._mvsec_types import MVSECOdometryData
+from ._storage_common import LoadingType
 
 
 __all__ = [
     "DataLoaderBase",
+    "LoadingType",
     "MVSECDataLoader",
     "MVSECOdometryData",
 ]

--- a/src/evlib/dataloaders/__init__.py
+++ b/src/evlib/dataloaders/__init__.py
@@ -1,8 +1,12 @@
 """Low level data loaders for event camera datasets."""
 
 from ._base import DataLoaderBase
+from ._mvsec import MVSECDataLoader
+from ._mvsec_types import MVSECOdometryData
 
 
 __all__ = [
     "DataLoaderBase",
+    "MVSECDataLoader",
+    "MVSECOdometryData",
 ]

--- a/src/evlib/dataloaders/_base.py
+++ b/src/evlib/dataloaders/_base.py
@@ -11,14 +11,12 @@ import abc
 from typing import Any
 from typing import Iterator
 from typing import Optional
-from typing import Self
 from typing import Tuple
 
 import numpy as np
 import numpy.typing as npt
 
 from evlib.types import RawEvents
-
 
 class DataLoaderBase(abc.ABC):
     """ABC for low level event data I/O
@@ -278,7 +276,7 @@ class DataLoaderBase(abc.ABC):
         last_event_time = self.index_to_time(last_event_index)
         return last_event_time
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> "DataLoaderBase":
         return self
 
     def __exit__(self, *exc: Any) -> None:

--- a/src/evlib/dataloaders/_base.py
+++ b/src/evlib/dataloaders/_base.py
@@ -12,11 +12,16 @@ from typing import Any
 from typing import Iterator
 from typing import Optional
 from typing import Tuple
+from typing import TypeVar
 
 import numpy as np
 import numpy.typing as npt
 
 from evlib.types import RawEvents
+
+
+_DataLoaderBaseT = TypeVar("_DataLoaderBaseT", bound="DataLoaderBase")
+
 
 class DataLoaderBase(abc.ABC):
     """ABC for low level event data I/O
@@ -276,7 +281,7 @@ class DataLoaderBase(abc.ABC):
         last_event_time = self.index_to_time(last_event_index)
         return last_event_time
 
-    def __enter__(self) -> "DataLoaderBase":
+    def __enter__(self: _DataLoaderBaseT) -> _DataLoaderBaseT:
         return self
 
     def __exit__(self, *exc: Any) -> None:

--- a/src/evlib/dataloaders/_base.py
+++ b/src/evlib/dataloaders/_base.py
@@ -7,12 +7,18 @@ It is a separate hierarchy from class EventDataset
 a Dataset uses a DataLoader via composition, but a DataLoader is not a Dataset.
 """
 
+from __future__ import annotations
+
 import abc
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
 from typing import Optional
-from typing import Self
 from typing import Tuple
+
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 import numpy as np
 import numpy.typing as npt

--- a/src/evlib/dataloaders/_base.py
+++ b/src/evlib/dataloaders/_base.py
@@ -11,6 +11,7 @@ import abc
 from typing import Any
 from typing import Iterator
 from typing import Optional
+from typing import Self
 from typing import Tuple
 
 import numpy as np
@@ -277,7 +278,7 @@ class DataLoaderBase(abc.ABC):
         last_event_time = self.index_to_time(last_event_index)
         return last_event_time
 
-    def __enter__(self) -> "DataLoaderBase":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *exc: Any) -> None:

--- a/src/evlib/dataloaders/_base.py
+++ b/src/evlib/dataloaders/_base.py
@@ -11,16 +11,13 @@ import abc
 from typing import Any
 from typing import Iterator
 from typing import Optional
+from typing import Self
 from typing import Tuple
-from typing import TypeVar
 
 import numpy as np
 import numpy.typing as npt
 
 from evlib.types import RawEvents
-
-
-_DataLoaderBaseT = TypeVar("_DataLoaderBaseT", bound="DataLoaderBase")
 
 
 class DataLoaderBase(abc.ABC):
@@ -281,7 +278,7 @@ class DataLoaderBase(abc.ABC):
         last_event_time = self.index_to_time(last_event_index)
         return last_event_time
 
-    def __enter__(self: _DataLoaderBaseT) -> _DataLoaderBaseT:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *exc: Any) -> None:

--- a/src/evlib/dataloaders/_event_cache.py
+++ b/src/evlib/dataloaders/_event_cache.py
@@ -1,0 +1,516 @@
+"""Reusable event sidecar cache and backend implementations."""
+
+import abc
+import hashlib
+import json
+import os
+import shutil
+import uuid
+from typing import Optional
+from typing import TypedDict
+from typing import cast
+
+import h5py
+import numpy as np
+import numpy.typing as npt
+from numpy.lib.format import open_memmap
+
+from evlib.codec.fileformat.hdf5 import open_hdf5
+from evlib.types import RawEvents
+
+
+_EVENT_CACHE_SCHEMA_VERSION = 1
+_EVENT_BUILD_BLOCK_ROWS = 1_000_000
+
+
+class _EventCacheMetadata(TypedDict):
+    schema_version: int
+    source_path: str
+    dataset_key: str
+    source_size: int
+    source_mtime_ns: int
+    num_events: int
+
+
+def _make_cache_signature(
+    source_path: str,
+    dataset_key: str,
+    source_size: int,
+    source_mtime_ns: int,
+) -> str:
+    """Return content addressed signature for an event source."""
+    parts = [
+        os.path.abspath(source_path),
+        dataset_key,
+        str(source_size),
+        str(source_mtime_ns),
+        str(_EVENT_CACHE_SCHEMA_VERSION),
+    ]
+    joined = "|".join(parts)
+    signature = hashlib.sha1(joined.encode("utf-8")).hexdigest()
+    return signature
+
+
+def _make_event_cache_dir(
+    cache_root: str,
+    source_path: str,
+    dataset_key: str,
+    cache_name: str,
+) -> str:
+    stat_result = os.stat(source_path)
+    source_size = int(stat_result.st_size)
+    source_mtime_ns = int(stat_result.st_mtime_ns)
+    signature = _make_cache_signature(
+        source_path,
+        dataset_key,
+        source_size,
+        source_mtime_ns,
+    )
+    directory_name = f"{cache_name}_{signature[:16]}"
+    return os.path.join(cache_root, "event_sidecars", directory_name)
+
+
+def _make_event_cache_paths(cache_dir: str) -> dict[str, str]:
+    return {
+        "x": os.path.join(cache_dir, "events_x.npy"),
+        "y": os.path.join(cache_dir, "events_y.npy"),
+        "timestamp": os.path.join(cache_dir, "events_t.npy"),
+        "polarity": os.path.join(cache_dir, "events_p.npy"),
+        "metadata": os.path.join(cache_dir, "metadata.json"),
+    }
+
+
+def _write_json(path: str, data: _EventCacheMetadata) -> None:
+    with open(path, "w", encoding="utf-8") as file_handle:
+        json.dump(data, file_handle, indent=2, sort_keys=True)
+
+
+def _load_event_cache_metadata(metadata_path: str) -> Optional[_EventCacheMetadata]:
+    if not os.path.isfile(metadata_path):
+        return None
+
+    with open(metadata_path, "r", encoding="utf-8") as file_handle:
+        metadata = cast(_EventCacheMetadata, json.load(file_handle))
+    return metadata
+
+
+def _event_cache_is_complete(
+    cache_dir: str,
+    source_path: str,
+    dataset_key: str,
+) -> Optional[_EventCacheMetadata]:
+    """Return metadata if the sidecar exists and still matches the source."""
+    paths = _make_event_cache_paths(cache_dir)
+    metadata = _load_event_cache_metadata(paths["metadata"])
+    if metadata is None:
+        return None
+
+    required_keys = ("x", "y", "timestamp", "polarity")
+    if not all(os.path.isfile(paths[key]) for key in required_keys):
+        return None
+
+    stat_result = os.stat(source_path)
+    source_size = int(stat_result.st_size)
+    source_mtime_ns = int(stat_result.st_mtime_ns)
+    source_path_abs = os.path.abspath(source_path)
+
+    is_stale = (
+        metadata["schema_version"] != _EVENT_CACHE_SCHEMA_VERSION
+        or metadata["source_path"] != source_path_abs
+        or metadata["dataset_key"] != dataset_key
+        or metadata["source_size"] != source_size
+        or metadata["source_mtime_ns"] != source_mtime_ns
+    )
+    if is_stale:
+        return None
+
+    return metadata
+
+
+def _copy_event_rows_into_columns(
+    event_dataset: h5py.Dataset,
+    x_values: npt.NDArray[np.int16],
+    y_values: npt.NDArray[np.int16],
+    timestamp_values: npt.NDArray[np.float64],
+    polarity_values: npt.NDArray[np.bool_],
+) -> None:
+    """Copy an HDF5 event table into typed column arrays blockwise."""
+    num_events = int(event_dataset.shape[0])
+    buffer = np.empty((_EVENT_BUILD_BLOCK_ROWS, 4), dtype=np.float64)
+    start_index = 0
+
+    while start_index < num_events:
+        end_index = min(start_index + _EVENT_BUILD_BLOCK_ROWS, num_events)
+        block = buffer[: end_index - start_index]
+        source_slice = np.s_[start_index:end_index, :]
+        event_dataset.read_direct(block, source_sel=source_slice)
+
+        x_values[start_index:end_index] = block[:, 0]
+        y_values[start_index:end_index] = block[:, 1]
+        timestamp_values[start_index:end_index] = block[:, 2]
+        np.greater(block[:, 3], 0.0, out=polarity_values[start_index:end_index])
+
+        start_index = end_index
+
+
+def _freeze_event_columns(
+    x_values: npt.NDArray[np.int16],
+    y_values: npt.NDArray[np.int16],
+    timestamp_values: npt.NDArray[np.float64],
+    polarity_values: npt.NDArray[np.bool_],
+) -> None:
+    arrays = (x_values, y_values, timestamp_values, polarity_values)
+    for array in arrays:
+        array.flags.writeable = False
+
+
+def _build_event_cache(
+    source_path: str,
+    dataset_key: str,
+    cache_dir: str,
+) -> _EventCacheMetadata:
+    """Build a typed event sidecar from an HDF5 events table."""
+    parent_dir = os.path.dirname(cache_dir)
+    os.makedirs(parent_dir, exist_ok=True)
+
+    temp_dir = os.path.join(parent_dir, f".tmp_{uuid.uuid4().hex}")
+    if os.path.isdir(temp_dir):
+        shutil.rmtree(temp_dir)
+    os.makedirs(temp_dir, exist_ok=True)
+
+    paths = _make_event_cache_paths(temp_dir)
+
+    try:
+        with open_hdf5(source_path) as h5_file:
+            event_dataset = h5_file[dataset_key]
+            num_events = int(event_dataset.shape[0])
+
+            x_values = open_memmap(paths["x"], mode="w+", dtype=np.int16, shape=(num_events,))
+            y_values = open_memmap(paths["y"], mode="w+", dtype=np.int16, shape=(num_events,))
+            timestamp_values = open_memmap(
+                paths["timestamp"],
+                mode="w+",
+                dtype=np.float64,
+                shape=(num_events,),
+            )
+            polarity_values = open_memmap(
+                paths["polarity"],
+                mode="w+",
+                dtype=np.bool_,
+                shape=(num_events,),
+            )
+
+            _copy_event_rows_into_columns(
+                event_dataset,
+                x_values,
+                y_values,
+                timestamp_values,
+                polarity_values,
+            )
+
+            x_values.flush()
+            y_values.flush()
+            timestamp_values.flush()
+            polarity_values.flush()
+
+        stat_result = os.stat(source_path)
+        metadata: _EventCacheMetadata = {
+            "schema_version": _EVENT_CACHE_SCHEMA_VERSION,
+            "source_path": os.path.abspath(source_path),
+            "dataset_key": dataset_key,
+            "source_size": int(stat_result.st_size),
+            "source_mtime_ns": int(stat_result.st_mtime_ns),
+            "num_events": num_events,
+        }
+        _write_json(paths["metadata"], metadata)
+
+        if os.path.isdir(cache_dir):
+            shutil.rmtree(cache_dir)
+        os.replace(temp_dir, cache_dir)
+        return metadata
+    except Exception:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise
+
+
+def _prepare_event_cache(
+    source_path: str,
+    dataset_key: str,
+    cache_name: str,
+    cache_root: str,
+) -> tuple[str, dict[str, str], _EventCacheMetadata]:
+    """Ensure an event sidecar exists and return its location and metadata."""
+    source_path_abs = os.path.abspath(source_path)
+    cache_dir = _make_event_cache_dir(
+        cache_root,
+        source_path_abs,
+        dataset_key,
+        cache_name,
+    )
+    paths = _make_event_cache_paths(cache_dir)
+    metadata = _event_cache_is_complete(cache_dir, source_path_abs, dataset_key)
+    if metadata is None:
+        metadata = _build_event_cache(source_path_abs, dataset_key, cache_dir)
+    return cache_dir, paths, metadata
+
+
+def load_cached_events(
+    source_path: str,
+    dataset_key: str,
+    cache_name: str,
+    cache_root: str,
+) -> tuple[
+    npt.NDArray[np.int16],
+    npt.NDArray[np.int16],
+    npt.NDArray[np.float64],
+    npt.NDArray[np.bool_],
+]:
+    """Load event columns from a persistent sidecar into ram."""
+    _, paths, _ = _prepare_event_cache(
+        source_path,
+        dataset_key,
+        cache_name,
+        cache_root,
+    )
+    x_values = np.load(paths["x"])
+    y_values = np.load(paths["y"])
+    timestamp_values = np.load(paths["timestamp"])
+    polarity_values = np.load(paths["polarity"])
+    _freeze_event_columns(
+        x_values,
+        y_values,
+        timestamp_values,
+        polarity_values,
+    )
+    return x_values, y_values, timestamp_values, polarity_values
+
+
+class _EventBackend(abc.ABC):
+    """Interface for loading slices of a typed event stream."""
+
+    @property
+    @abc.abstractmethod
+    def num_events(self) -> int: ...
+
+    @abc.abstractmethod
+    def load_events(self, start_index: int, end_index: int) -> RawEvents: ...
+
+    @abc.abstractmethod
+    def time_to_index(self, t: float) -> int:
+        """Return the last event index strictly before ``t``."""
+
+    @abc.abstractmethod
+    def index_to_time(self, index: int) -> float: ...
+
+    @abc.abstractmethod
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]: ...
+
+    @abc.abstractmethod
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]: ...
+
+    @abc.abstractmethod
+    def close(self) -> None: ...
+
+
+class _CachedEventBackend(_EventBackend):
+    """Event backend with all event columns resident in RAM."""
+
+    def __init__(
+        self,
+        x_values: npt.NDArray[np.int16],
+        y_values: npt.NDArray[np.int16],
+        timestamp_values: npt.NDArray[np.float64],
+        polarity_values: npt.NDArray[np.bool_],
+    ) -> None:
+        self._x = x_values
+        self._y = y_values
+        self._timestamp = timestamp_values
+        self._polarity = polarity_values
+
+    @classmethod
+    def from_event_dataset(cls, event_dataset: h5py.Dataset) -> "_CachedEventBackend":
+        """Read directly from HDF5 into frozen typed columns."""
+        num_events = int(event_dataset.shape[0])
+        x_values = np.empty(num_events, dtype=np.int16)
+        y_values = np.empty(num_events, dtype=np.int16)
+        timestamp_values = np.empty(num_events, dtype=np.float64)
+        polarity_values = np.empty(num_events, dtype=np.bool_)
+
+        _copy_event_rows_into_columns(
+            event_dataset,
+            x_values,
+            y_values,
+            timestamp_values,
+            polarity_values,
+        )
+        _freeze_event_columns(
+            x_values,
+            y_values,
+            timestamp_values,
+            polarity_values,
+        )
+        return cls(
+            x_values,
+            y_values,
+            timestamp_values,
+            polarity_values,
+        )
+
+    @classmethod
+    def from_sidecar(
+        cls,
+        source_path: str,
+        dataset_key: str,
+        cache_name: str,
+        cache_root: str,
+    ) -> "_CachedEventBackend":
+        """Load typed columns from a persistent sidecar into RAM."""
+        x_values, y_values, timestamp_values, polarity_values = load_cached_events(
+            source_path,
+            dataset_key,
+            cache_name,
+            cache_root,
+        )
+        return cls(
+            x_values,
+            y_values,
+            timestamp_values,
+            polarity_values,
+        )
+
+    @property
+    def num_events(self) -> int:
+        return len(self._timestamp)
+
+    def load_events(self, start_index: int, end_index: int) -> RawEvents:
+        event_slice = slice(start_index, end_index)
+        return RawEvents(
+            x=self._x[event_slice].copy(),
+            y=self._y[event_slice].copy(),
+            timestamp=self._timestamp[event_slice].copy(),
+            polarity=self._polarity[event_slice].copy(),
+        )
+
+    def time_to_index(self, t: float) -> int:
+        return int(self._timestamp.searchsorted(t, side="left") - 1)
+
+    def index_to_time(self, index: int) -> float:
+        return float(self._timestamp[index])
+
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        timestamp_array = np.asarray(timestamps, dtype=np.float64)
+        indices = self._timestamp.searchsorted(timestamp_array, side="left") - 1
+        return np.asarray(indices, dtype=np.int64)
+
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        index_array = np.asarray(indices, dtype=np.int64)
+        timestamps = self._timestamp[index_array]
+        return np.asarray(timestamps, dtype=np.float64)
+
+    def close(self) -> None:
+        return None
+
+
+class _LazyEventBackend(_EventBackend):
+    """Sidecar backed event backend using read only NumPy memmaps."""
+
+    def __init__(
+        self,
+        source_path: str,
+        dataset_key: str,
+        cache_name: str,
+        cache_root: str,
+    ) -> None:
+        self._cache_dir, self._cache_paths, metadata = _prepare_event_cache(
+            source_path,
+            dataset_key,
+            cache_name,
+            cache_root,
+        )
+        self._num_events = int(metadata["num_events"])
+        self._x: Optional[npt.NDArray[np.int16]] = None
+        self._y: Optional[npt.NDArray[np.int16]] = None
+        self._timestamp: Optional[npt.NDArray[np.float64]] = None
+        self._polarity: Optional[npt.NDArray[np.bool_]] = None
+        self._pid: Optional[int] = None
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["_x"] = None
+        state["_y"] = None
+        state["_timestamp"] = None
+        state["_polarity"] = None
+        state["_pid"] = None
+        return state
+
+    @property
+    def num_events(self) -> int:
+        return self._num_events
+
+    def _ensure_open(self) -> None:
+        pid = os.getpid()
+        has_arrays = (
+            self._x is not None
+            and self._y is not None
+            and self._timestamp is not None
+            and self._polarity is not None
+        )
+        if self._pid == pid and has_arrays:
+            return
+
+        self._x = np.load(self._cache_paths["x"], mmap_mode="r")
+        self._y = np.load(self._cache_paths["y"], mmap_mode="r")
+        self._timestamp = np.load(self._cache_paths["timestamp"], mmap_mode="r")
+        self._polarity = np.load(self._cache_paths["polarity"], mmap_mode="r")
+        self._pid = pid
+
+    def load_events(self, start_index: int, end_index: int) -> RawEvents:
+        self._ensure_open()
+
+        assert self._x is not None
+        assert self._y is not None
+        assert self._timestamp is not None
+        assert self._polarity is not None
+
+        event_slice = slice(start_index, end_index)
+        return RawEvents(
+            x=self._x[event_slice].copy(),
+            y=self._y[event_slice].copy(),
+            timestamp=self._timestamp[event_slice].copy(),
+            polarity=self._polarity[event_slice].copy(),
+        )
+
+    def time_to_index(self, t: float) -> int:
+        self._ensure_open()
+
+        assert self._timestamp is not None
+        return int(self._timestamp.searchsorted(t, side="left") - 1)
+
+    def index_to_time(self, index: int) -> float:
+        self._ensure_open()
+
+        assert self._timestamp is not None
+        return float(self._timestamp[index])
+
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        self._ensure_open()
+
+        assert self._timestamp is not None
+        timestamp_array = np.asarray(timestamps, dtype=np.float64)
+        indices = self._timestamp.searchsorted(timestamp_array, side="left") - 1
+        return np.asarray(indices, dtype=np.int64)
+
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        self._ensure_open()
+
+        assert self._timestamp is not None
+        index_array = np.asarray(indices, dtype=np.int64)
+        timestamps = self._timestamp[index_array]
+        return np.asarray(timestamps, dtype=np.float64)
+
+    def close(self) -> None:
+        self._x = None
+        self._y = None
+        self._timestamp = None
+        self._polarity = None
+        self._pid = None

--- a/src/evlib/dataloaders/_event_cache.py
+++ b/src/evlib/dataloaders/_event_cache.py
@@ -1,5 +1,7 @@
 """Reusable event sidecar cache and backend implementations."""
 
+from __future__ import annotations
+
 import abc
 import hashlib
 import json

--- a/src/evlib/dataloaders/_mvsec.py
+++ b/src/evlib/dataloaders/_mvsec.py
@@ -14,6 +14,8 @@ The Multi Vehicle Stereo Event Camera Dataset: An Event Camera Dataset for 3D Pe
 IEEE Robotics and Automation Letters, 3(3), 2032-2039.
 """
 
+from __future__ import annotations
+
 import concurrent.futures
 import logging
 import os

--- a/src/evlib/dataloaders/_mvsec.py
+++ b/src/evlib/dataloaders/_mvsec.py
@@ -1,0 +1,1272 @@
+"""Low level I/O dataloader for the MVSEC dataset.
+
+Extracts all file access (HDF5, NPZ, calibration) from the dataset layer
+so can be use for flexible access patterns
+
+Supports all MVSEC data modalities (events, images, IMU, depth, poses,
+odometry, optical flow, velodyne lidar) with per modality lazy/cached
+loading control.
+
+Reference: https://daniilidis-group.github.io/mvsec/
+
+Zhu, A. Z., Thakur, D., Ozaslan, T., Pfrommer, B., Kumar, V., & Daniilidis, K. (2018).
+The Multi Vehicle Stereo Event Camera Dataset: An Event Camera Dataset for 3D Perception.
+IEEE Robotics and Automation Letters, 3(3), 2032-2039.
+"""
+
+import concurrent.futures
+import logging
+import os
+import warnings
+from functools import lru_cache
+from typing import Any, Dict, Literal, Optional, Tuple, Union, cast
+
+import h5py
+import numpy as np
+import numpy.typing as npt
+
+_cv2: Any = None
+
+try:
+    import cv2 as _cv2
+except ImportError:
+    _cv2 = None
+
+cv2: Any = _cv2
+
+from evlib.codec.fileformat.hdf5 import open_hdf5
+from evlib.types import RawEvents
+
+from ._base import DataLoaderBase
+from ._mvsec_storage import _CachedEventBackend
+from ._mvsec_storage import _EventBackend
+from ._mvsec_storage import _LazyEventBackend
+from ._mvsec_storage import _LazyH5Dataset
+from ._mvsec_storage import ResidentLoadMode
+from ._mvsec_storage import load_mvsec_gt_flow
+from ._mvsec_storage import normalize_resident_load_mode
+from ._mvsec_storage import resolve_mvsec_cache_dir
+from ._mvsec_types import MVSECOdometryData
+
+
+logger = logging.getLogger(__name__)
+
+# False = off, True/"lazy" = on demand, "cached" = in memory
+LoadMode = Union[bool, Literal["lazy", "cached"]]
+
+
+# Module lvl helpers
+
+
+def _resolve_load_mode(value: LoadMode) -> Tuple[bool, bool]:
+    """Parse a LoadMode into (should_load, should_cache)."""
+    if value is False:
+        return (False, False)
+    if value is True or value == "lazy":
+        return (True, False)
+    if value == "cached":
+        return (True, True)
+    raise ValueError(f"Invalid load mode: {value!r}. Expected False, True, 'lazy', or 'cached'.")
+
+
+def _resolve_depth_load_modes(
+    load_gt_depth_raw: LoadMode,
+    load_gt_depth_rect: LoadMode,
+) -> Tuple[Tuple[bool, bool], Tuple[bool, bool]]:
+    return _resolve_load_mode(load_gt_depth_raw), _resolve_load_mode(load_gt_depth_rect)
+
+
+def _load_calibration(
+    root: str, category: str, camera: str
+) -> Optional[Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
+    """Load calibration rectification maps from text files."""
+    name_x = f"{category}_{camera}_x_map.txt"
+    name_y = f"{category}_{camera}_y_map.txt"
+    for d in [root, os.path.join(root, f"{category}_calib")]:
+        xp = os.path.join(d, name_x)
+        yp = os.path.join(d, name_y)
+        if os.path.isfile(xp) and os.path.isfile(yp):
+            return np.loadtxt(xp), np.loadtxt(yp)
+    return None
+
+
+def _load_odometry_npz(npz_path: str) -> Optional[MVSECOdometryData]:
+    npz = np.load(npz_path)
+    return MVSECOdometryData(
+        timestamps=np.asarray(npz["timestamps"], dtype=np.float64),
+        linear_velocity=np.asarray(npz["lin_vel"], dtype=np.float64),
+        position=np.asarray(npz["pos"], dtype=np.float64),
+        quaternion=np.asarray(npz["quat"], dtype=np.float64),
+        angular_velocity=np.asarray(npz["ang_vel"], dtype=np.float64),
+    )
+
+
+def _find_nearest_index(timestamps: npt.NDArray[np.float64], t: float) -> int:
+    """Index of the timestamp nearest to *t*."""
+    idx = int(np.searchsorted(timestamps, t, side="left"))
+
+    if idx >= len(timestamps):
+        return len(timestamps) - 1
+    if idx == 0:
+        return 0
+
+    left_dist = abs(t - timestamps[idx - 1])
+    right_dist = abs(t - timestamps[idx])
+    return idx - 1 if left_dist <= right_dist else idx
+
+
+@lru_cache(maxsize=8)
+def _get_flow_coordinate_grid(
+    h: int,
+    w: int,
+) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
+    """Cached base coordinate grids for dense flow propagation."""
+    xc, yc = np.meshgrid(
+        np.arange(w, dtype=np.float32),
+        np.arange(h, dtype=np.float32),
+        indexing="xy",
+    )
+    xc.flags.writeable = False
+    yc.flags.writeable = False
+    return xc, yc
+
+
+def _sample_flow_nearest_numpy(
+    x_flow: npt.NDArray[np.float32],
+    y_flow: npt.NDArray[np.float32],
+    x_coords: npt.NDArray[np.float32],
+    y_coords: npt.NDArray[np.float32],
+) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
+    """Pure numpy fallback for nearest neighbor flow sampling."""
+    rx = np.rint(x_coords).astype(np.int32)
+    ry = np.rint(y_coords).astype(np.int32)
+
+    h, w = x_flow.shape
+    valid = (rx >= 0) & (rx < w) & (ry >= 0) & (ry < h)
+
+    sx = np.zeros_like(x_flow, dtype=np.float32)
+    sy = np.zeros_like(y_flow, dtype=np.float32)
+    if np.any(valid):
+        sx[valid] = x_flow[ry[valid], rx[valid]]
+        sy[valid] = y_flow[ry[valid], rx[valid]]
+
+    return sx, sy, valid
+
+
+def _sample_flow_nearest(
+    x_flow: npt.NDArray[np.float32],
+    y_flow: npt.NDArray[np.float32],
+    x_coords: npt.NDArray[np.float32],
+    y_coords: npt.NDArray[np.float32],
+) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
+    """Sample dense flow at floating point coordinates, opencv if available."""
+    rx = np.rint(x_coords).astype(np.int32)
+    ry = np.rint(y_coords).astype(np.int32)
+
+    h, w = x_flow.shape
+    valid = (rx >= 0) & (rx < w) & (ry >= 0) & (ry < h)
+
+    if cv2 is None:
+        return _sample_flow_nearest_numpy(x_flow, y_flow, x_coords, y_coords)
+
+    sx = np.asarray(
+        cv2.remap(
+            x_flow,
+            x_coords,
+            y_coords,
+            interpolation=cv2.INTER_NEAREST,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=0,
+        ),
+        dtype=np.float32,
+    )
+    sy = np.asarray(
+        cv2.remap(
+            y_flow,
+            x_coords,
+            y_coords,
+            interpolation=cv2.INTER_NEAREST,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=0,
+        ),
+        dtype=np.float32,
+    )
+    return sx, sy, valid
+
+
+def _propagate_flow_step(
+    x_flow: npt.NDArray[np.float32],
+    y_flow: npt.NDArray[np.float32],
+    x_coords: npt.NDArray[np.float32],
+    y_coords: npt.NDArray[np.float32],
+    x_mask: npt.NDArray[np.bool_],
+    y_mask: npt.NDArray[np.bool_],
+    scale: float,
+) -> None:
+    """Propagate pixel coordinates through one GT flow field (in place)."""
+    sx, sy, valid = _sample_flow_nearest(x_flow, y_flow, x_coords, y_coords)
+
+    x_mask &= valid
+    y_mask &= valid
+    x_mask[sx == 0.0] = False
+    y_mask[sy == 0.0] = False
+
+    x_coords += sx * scale
+    y_coords += sy * scale
+
+
+def _estimate_interval_flow(
+    x_flow_all: npt.NDArray[np.float32],
+    y_flow_all: npt.NDArray[np.float32],
+    gt_timestamps: npt.NDArray[np.float64],
+    t_start: float,
+    t_end: float,
+) -> npt.NDArray[np.float32]:
+    """Estimate pixel displacement over [t_start, t_end) from GT flow frames.
+
+    GT flow is given at discrete timestamps. For arbitrary intervals
+    either scale a single frame (fast path) or chain propagate across
+    multiple frames tracking where each pixel ends up.
+    """
+    if t_end <= t_start:
+        raise ValueError(f"Expected t_end > t_start, got [{t_start}, {t_end}).")
+    if len(gt_timestamps) < 2:
+        raise ValueError("At least two GT flow timestamps are required.")
+    if t_start < float(gt_timestamps[0]) or t_end > float(gt_timestamps[-1]):
+        raise ValueError(
+            f"Interval [{t_start}, {t_end}) falls outside GT support "
+            f"[{gt_timestamps[0]}, {gt_timestamps[-1]}]."
+        )
+
+    last_flow_idx = len(gt_timestamps) - 2
+    start_idx = int(np.searchsorted(gt_timestamps, t_start, side="right")) - 1
+    if start_idx < 0 or start_idx > last_flow_idx:
+        raise ValueError(
+            f"Could not resolve a GT flow interval for start time {t_start}. "
+            f"GT timestamps range: [{gt_timestamps[0]}, {gt_timestamps[-1]}]"
+        )
+
+    gt_t0 = float(gt_timestamps[start_idx])
+    gt_t1 = float(gt_timestamps[start_idx + 1])
+    gt_dt = gt_t1 - gt_t0
+    req_dt = t_end - t_start
+    remaining = gt_t1 - t_start
+
+    # fast path - requested window fits inside one GT interval
+    if gt_dt >= req_dt and remaining >= req_dt:
+        scale = np.float32(req_dt / gt_dt)
+        fx = x_flow_all[start_idx].copy() * scale
+        fy = y_flow_all[start_idx].copy() * scale
+        h, w = fx.shape
+        out = np.empty((h, w, 2), dtype=np.float32)
+        out[..., 0] = fx
+        out[..., 1] = fy
+        return out
+
+    # slow path - walk pixel coords through multiple GT intervals
+    # leading partial -> full middle intervals -> trailing partial
+    h, w = x_flow_all.shape[1], x_flow_all.shape[2]
+    origin_x, origin_y = _get_flow_coordinate_grid(h, w)
+    xc = origin_x.copy()
+    yc = origin_y.copy()
+    xm = np.ones((h, w), dtype=np.bool_)
+    ym = np.ones((h, w), dtype=np.bool_)
+
+    # leading partial
+    _propagate_flow_step(
+        x_flow_all[start_idx],
+        y_flow_all[start_idx],
+        xc,
+        yc,
+        xm,
+        ym,
+        remaining / gt_dt,
+    )
+
+    # full middle intervals
+    i = start_idx + 1
+    while i < last_flow_idx:
+        if float(gt_timestamps[i + 1]) >= t_end:
+            break
+        _propagate_flow_step(
+            x_flow_all[i],
+            y_flow_all[i],
+            xc,
+            yc,
+            xm,
+            ym,
+            1.0,
+        )
+        i += 1
+
+    # trailing partial
+    trail_t0 = float(gt_timestamps[i])
+    trail_t1 = float(gt_timestamps[i + 1])
+    trail_scale = (t_end - trail_t0) / (trail_t1 - trail_t0)
+    _propagate_flow_step(
+        x_flow_all[i],
+        y_flow_all[i],
+        xc,
+        yc,
+        xm,
+        ym,
+        trail_scale,
+    )
+
+    # displacement = where pixels ended up minus where they started
+    dx = xc - origin_x
+    dy = yc - origin_y
+    dx[~xm] = 0.0
+    dy[~ym] = 0.0
+
+    out = np.empty((h, w, 2), dtype=np.float32)
+    out[..., 0] = dx
+    out[..., 1] = dy
+    return out
+
+
+def _freeze_array(arr: "Optional[npt.NDArray[np.generic]]") -> None:
+    if arr is not None:
+        arr.flags.writeable = False
+
+
+# MVSECDataLoader
+
+
+class MVSECDataLoader(DataLoaderBase):
+    """Low level I/O for a single MVSEC sequence.
+
+    Handles HDF5 reading, NPZ decompression, calibration loading, and
+    typed column caching.  Use directly for custom access patterns
+    (overlapping windows, multiscale, etc.) or let MVSECDataset wrap it
+    for PyTorch style frame indexed sampling.
+
+    Large HDF5 backed modalities (depth, blended images, HDF5 flow, and
+    velodyne) support a per modality loading strategy via the ``LoadMode``
+    tristate:
+
+    - ``False`` -- do not load this modality.
+    - ``True`` or ``"lazy"`` -- lazy load on demand (HDF5 handle stays open).
+    - ``"cached"`` -- read entirely into memory during ``__init__``.
+
+    Small modalities (IMU, odometry NPZ, GT odometry, GT poses) are always
+    cached in memory when enabled because they are tiny.
+
+    The default profile is intentionally lean:
+
+    - events are cached in RAM
+    - grayscale images are cached in RAM
+    - optional GT and calibration modalities stay disabled until requested
+
+    Args:
+        root: Directory containing the MVSEC dataset files.
+        sequence: Sequence name (e.g. ``"indoor_flying1"``).
+        camera: ``"left"`` or ``"right"``.
+        load_gt_flow: LoadMode for GT optical flow from NPZ.
+        load_calibration: If True, load calibration rectification maps.
+        load_imu: If True, cache IMU data from data HDF5.
+        load_odometry_npz: If True, cache odometry from ``*_odom.npz``.
+        load_gt_odometry: If True, cache LOAM odometry SE(3) from gt HDF5.
+        load_gt_poses: If True, cache Cartographer poses SE(3) from gt HDF5.
+        load_gt_depth_raw: LoadMode for raw depth maps from gt HDF5.
+        load_gt_depth_rect: LoadMode for rectified depth maps from gt HDF5.
+        load_gt_flow_hdf5: LoadMode for optical flow from gt HDF5.
+        load_gt_blended: LoadMode for blended images from gt HDF5.
+        load_velodyne: LoadMode for velodyne lidar from data HDF5.
+        event_load_mode: ``"cached"`` to keep all events in RAM or ``"lazy"``
+            to build and use a typed read only sidecar cache.
+        image_load_mode: ``"cached"`` to keep all images in RAM or ``"lazy"``
+            to read frames from HDF5 on demand.
+        cache_dir: Optional root directory for MVSEC sidecar caches.
+    """
+
+    IMAGE_SHAPE: Tuple[int, int] = (260, 346)  # (h, w)
+
+    # these are GT flow specific , may likely be better to move to a config in future
+    VALID_FRAMES: Dict[str, Tuple[int, Optional[int]]] = {
+        "indoor_flying1": (60, 1340),
+        "indoor_flying2": (140, 1500),
+        "indoor_flying3": (100, 1711),
+        "indoor_flying4": (104, 380),
+        "outdoor_day1": (0, 5020),
+        "outdoor_day2": (30, None),
+    }
+
+    def __init__(
+        self,
+        root: str,
+        sequence: str,
+        camera: str = "left",
+        load_gt_flow: LoadMode = False,
+        load_calibration: bool = False,
+        load_imu: bool = False,
+        load_odometry_npz: bool = False,
+        load_gt_odometry: bool = False,
+        load_gt_poses: bool = False,
+        load_gt_depth_raw: LoadMode = False,
+        load_gt_depth_rect: LoadMode = False,
+        load_gt_flow_hdf5: LoadMode = False,
+        load_gt_blended: LoadMode = False,
+        load_velodyne: LoadMode = False,
+        event_load_mode: ResidentLoadMode = "cached",
+        image_load_mode: ResidentLoadMode = "cached",
+        cache_dir: Optional[str] = None,
+    ) -> None:
+        self.root = root
+        self.sequence = sequence
+        if camera not in ("left", "right"):
+            raise ValueError(f"camera must be 'left' or 'right', got '{camera}'")
+        self.camera = camera
+        has_explicit_cache = cache_dir is not None
+        self._event_load_mode = normalize_resident_load_mode("event_load_mode", event_load_mode)
+        self._image_load_mode = normalize_resident_load_mode("image_load_mode", image_load_mode)
+        self._cache_dir = resolve_mvsec_cache_dir(cache_dir)
+
+        raw_depth_modes, rect_depth_modes = _resolve_depth_load_modes(
+            load_gt_depth_raw,
+            load_gt_depth_rect,
+        )
+        do_load_gt_flow, do_cache_gt_flow = _resolve_load_mode(load_gt_flow)
+        do_load_depth_raw, do_cache_depth_raw = raw_depth_modes
+        do_load_depth_rect, do_cache_depth_rect = rect_depth_modes
+        do_load_flow_h5, do_cache_flow_h5 = _resolve_load_mode(load_gt_flow_hdf5)
+        do_load_blended, do_cache_blended = _resolve_load_mode(load_gt_blended)
+        do_load_velodyne, do_cache_velodyne = _resolve_load_mode(load_velodyne)
+
+        hdf5_path = os.path.join(root, f"{sequence}_data.hdf5")
+        self._data_hdf5_path = hdf5_path
+        davis_key = f"davis/{camera}"
+        self._davis_key = davis_key
+
+        npz_path = os.path.join(root, f"{sequence}_gt_flow_dist.npz")
+        category = sequence.rstrip("0123456789")
+
+        has_gt_npz = do_load_gt_flow and os.path.isfile(npz_path)
+        odom_npz_path = os.path.join(root, f"{sequence}_odom.npz")
+        has_odom_npz = load_odometry_npz and os.path.isfile(odom_npz_path)
+
+        # calibration and odometry are independent file reads so kick
+        # them off in threads while the main thread handles HDF5
+        executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+        if load_calibration or has_odom_npz:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+        calib_future = (
+            executor.submit(_load_calibration, root, category, camera)
+            if executor and load_calibration
+            else None
+        )
+        odom_future = (
+            executor.submit(_load_odometry_npz, odom_npz_path)
+            if executor and has_odom_npz
+            else None
+        )
+
+        self._images: Optional[npt.NDArray[np.uint8]] = None
+        self._images_lazy: Optional[_LazyH5Dataset] = None
+        self._has_images = False
+        self._frame_ts: Optional[npt.NDArray[np.float64]] = None
+        self._frame_event_inds: Optional[npt.NDArray[np.int64]] = None
+        self._imu: Optional[npt.NDArray[np.float64]] = None
+        self._imu_ts: Optional[npt.NDArray[np.float64]] = None
+        self._velodyne_cached: Optional[npt.NDArray[np.float32]] = None
+        self._velodyne_lazy: Optional[_LazyH5Dataset] = None
+        self._velodyne_ts: Optional[npt.NDArray[np.float64]] = None
+
+        with open_hdf5(hdf5_path) as data_h5:
+            davis = data_h5[davis_key]
+
+            # pick event backend - cached = all in RAM, lazy = sidecar mmap
+            self._event_backend: _EventBackend
+            if self._event_load_mode == "cached":
+                if has_explicit_cache:
+                    # try sidecar first, fallback direct HDF5 if broken
+                    try:
+                        self._event_backend = _CachedEventBackend.from_sidecar(
+                            source_path=hdf5_path,
+                            dataset_key=f"{davis_key}/events",
+                            sequence=sequence,
+                            camera=camera,
+                            cache_root=self._cache_dir,
+                        )
+                    except OSError:
+                        self._event_backend = _CachedEventBackend.from_event_dataset(
+                            davis["events"]
+                        )
+                else:
+                    self._event_backend = _CachedEventBackend.from_event_dataset(davis["events"])
+            else:
+                self._event_backend = _LazyEventBackend(
+                    source_path=hdf5_path,
+                    dataset_key=f"{davis_key}/events",
+                    sequence=sequence,
+                    camera=camera,
+                    cache_root=self._cache_dir,
+                )
+
+            if "image_raw_ts" in davis:
+                self._frame_ts = np.array(davis["image_raw_ts"], dtype=np.float64)
+
+            if "image_raw_event_inds" in davis:
+                self._frame_event_inds = np.array(davis["image_raw_event_inds"], dtype=np.int64)
+
+            self._has_images = "image_raw" in davis
+            if self._has_images:
+                if self._image_load_mode == "cached":
+                    self._images = np.array(davis["image_raw"], dtype=np.uint8)
+                else:
+                    self._images_lazy = _LazyH5Dataset(
+                        hdf5_path,
+                        f"{davis_key}/image_raw",
+                        np.uint8,
+                    )
+
+            if load_imu:
+                if "imu" in davis:
+                    self._imu = np.array(davis["imu"], dtype=np.float64)
+                    self._imu_ts = np.array(davis["imu_ts"], dtype=np.float64)
+                else:
+                    logger.warning("IMU data not found in %s", hdf5_path)
+
+            if do_load_velodyne:
+                if "velodyne" in data_h5 and "scans" in data_h5["velodyne"]:
+                    vel = data_h5["velodyne"]
+                    self._velodyne_ts = np.array(vel["scans_ts"], dtype=np.float64)
+                    if do_cache_velodyne:
+                        self._velodyne_cached = np.array(vel["scans"], dtype=np.float32)
+                    else:
+                        self._velodyne_lazy = _LazyH5Dataset(
+                            hdf5_path,
+                            "velodyne/scans",
+                            np.float32,
+                        )
+                else:
+                    logger.warning("Velodyne data not found in %s", hdf5_path)
+
+        gt_hdf5_path = os.path.join(root, f"{sequence}_gt.hdf5")
+        self._gt_hdf5_path = gt_hdf5_path
+
+        self._gt_odometry: Optional[npt.NDArray[np.float64]] = None
+        self._gt_odometry_ts: Optional[npt.NDArray[np.float64]] = None
+        self._gt_pose: Optional[npt.NDArray[np.float64]] = None
+        self._gt_pose_ts: Optional[npt.NDArray[np.float64]] = None
+        self._depth_raw_cached: Optional[npt.NDArray[np.float32]] = None
+        self._depth_raw_lazy: Optional[_LazyH5Dataset] = None
+        self._depth_raw_ts: Optional[npt.NDArray[np.float64]] = None
+        self._depth_rect_cached: Optional[npt.NDArray[np.float32]] = None
+        self._depth_rect_lazy: Optional[_LazyH5Dataset] = None
+        self._depth_rect_ts: Optional[npt.NDArray[np.float64]] = None
+        self._blended_cached: Optional[npt.NDArray[np.uint8]] = None
+        self._blended_lazy: Optional[_LazyH5Dataset] = None
+        self._blended_ts: Optional[npt.NDArray[np.float64]] = None
+        self._flow_h5_cached: Optional[npt.NDArray[np.float64]] = None
+        self._flow_h5_lazy: Optional[_LazyH5Dataset] = None
+        self._flow_h5_ts: Optional[npt.NDArray[np.float64]] = None
+
+        needs_gt_h5 = (
+            do_load_depth_raw
+            or do_load_depth_rect
+            or load_gt_odometry
+            or load_gt_poses
+            or do_load_flow_h5
+            or do_load_blended
+        )
+        if needs_gt_h5 and os.path.isfile(gt_hdf5_path):
+            with open_hdf5(gt_hdf5_path) as gt_h5:
+                gt_key = f"davis/{camera}"
+                gt_group = gt_h5[gt_key] if gt_key in gt_h5 else None
+
+                if gt_group is None:
+                    logger.warning("Camera '%s' not found in %s", camera, gt_hdf5_path)
+                else:
+                    self._load_gt_small_data(gt_group, load_gt_odometry, load_gt_poses)
+                    self._load_gt_large_data(
+                        gt_group,
+                        gt_hdf5_path,
+                        gt_key,
+                        do_load_depth_raw,
+                        do_cache_depth_raw,
+                        do_load_depth_rect,
+                        do_cache_depth_rect,
+                        do_load_flow_h5,
+                        do_cache_flow_h5,
+                        do_load_blended,
+                        do_cache_blended,
+                    )
+        elif needs_gt_h5:
+            logger.warning("GT HDF5 file not found: %s", gt_hdf5_path)
+
+        self._gt_x_flow: Optional[npt.NDArray[np.float32]] = None
+        self._gt_y_flow: Optional[npt.NDArray[np.float32]] = None
+        self._gt_ts: Optional[npt.NDArray[np.float64]] = None
+        if has_gt_npz:
+            mode: ResidentLoadMode = "cached" if do_cache_gt_flow else "lazy"
+            self._gt_x_flow, self._gt_y_flow, self._gt_ts = load_mvsec_gt_flow(
+                npz_path,
+                sequence,
+                self._cache_dir,
+                mode,
+            )
+        elif do_load_gt_flow:
+            logger.warning("GT flow file not found: %s", npz_path)
+
+        self._x_map: Optional[npt.NDArray[np.float64]] = None
+        self._y_map: Optional[npt.NDArray[np.float64]] = None
+        if calib_future is not None:
+            calib_result = calib_future.result()
+            if calib_result is not None:
+                self._x_map, self._y_map = calib_result
+            else:
+                dirs = [root, os.path.join(root, f"{category}_calib")]
+                logger.warning("Calibration map(s) not found for %s in %s", camera, dirs)
+
+        self._odometry_npz: Optional[MVSECOdometryData] = None
+        if odom_future is not None:
+            odom_result = odom_future.result()
+            if odom_result is not None:
+                self._odometry_npz = odom_result
+        elif load_odometry_npz:
+            logger.warning("Odometry NPZ file not found: %s", odom_npz_path)
+
+        if executor is not None:
+            executor.shutdown(wait=False)
+
+        # freeze everything we loaded into memory
+        for arr in [
+            self._frame_ts,
+            self._frame_event_inds,
+            self._images,
+            self._gt_x_flow,
+            self._gt_y_flow,
+            self._gt_ts,
+            self._x_map,
+            self._y_map,
+            self._imu,
+            self._imu_ts,
+            self._velodyne_cached,
+            self._velodyne_ts,
+            self._gt_odometry,
+            self._gt_odometry_ts,
+            self._gt_pose,
+            self._gt_pose_ts,
+            self._depth_raw_cached,
+            self._depth_raw_ts,
+            self._depth_rect_cached,
+            self._depth_rect_ts,
+            self._blended_cached,
+            self._blended_ts,
+            self._flow_h5_cached,
+            self._flow_h5_ts,
+        ]:
+            _freeze_array(arr)
+
+        if self._odometry_npz is not None:
+            for arr in [
+                self._odometry_npz.timestamps,
+                self._odometry_npz.linear_velocity,
+                self._odometry_npz.position,
+                self._odometry_npz.quaternion,
+                self._odometry_npz.angular_velocity,
+            ]:
+                _freeze_array(arr)
+
+    # Private init helpers
+
+    def _load_gt_small_data(
+        self,
+        gt_group: h5py.Group,
+        load_gt_odometry: bool,
+        load_gt_poses: bool,
+    ) -> None:
+        if load_gt_odometry:
+            if "odometry" in gt_group:
+                self._gt_odometry = np.array(gt_group["odometry"], dtype=np.float64)
+                self._gt_odometry_ts = np.array(gt_group["odometry_ts"], dtype=np.float64)
+            else:
+                logger.warning("GT odometry not found in gt HDF5.")
+
+        if load_gt_poses:
+            if "pose" in gt_group:
+                self._gt_pose = np.array(gt_group["pose"], dtype=np.float64)
+                self._gt_pose_ts = np.array(gt_group["pose_ts"], dtype=np.float64)
+            else:
+                logger.warning("GT pose not found in gt HDF5.")
+
+    def _load_gt_large_data(
+        self,
+        gt_group: h5py.Group,
+        gt_hdf5_path: str,
+        gt_davis_key: str,
+        do_load_depth_raw: bool,
+        do_cache_depth_raw: bool,
+        do_load_depth_rect: bool,
+        do_cache_depth_rect: bool,
+        do_load_flow_h5: bool,
+        do_cache_flow_h5: bool,
+        do_load_blended: bool,
+        do_cache_blended: bool,
+    ) -> None:
+        """Load or set up lazy refs for large GT datasets."""
+        if do_load_depth_raw:
+            if "depth_image_raw" in gt_group:
+                self._depth_raw_ts = np.array(gt_group["depth_image_raw_ts"], dtype=np.float64)
+                if do_cache_depth_raw:
+                    self._depth_raw_cached = np.array(gt_group["depth_image_raw"], dtype=np.float32)
+                else:
+                    self._depth_raw_lazy = _LazyH5Dataset(
+                        gt_hdf5_path,
+                        f"{gt_davis_key}/depth_image_raw",
+                        np.float32,
+                    )
+            else:
+                logger.warning("depth_image_raw not found in gt HDF5.")
+
+        if do_load_depth_rect:
+            if "depth_image_rect" in gt_group:
+                self._depth_rect_ts = np.array(gt_group["depth_image_rect_ts"], dtype=np.float64)
+                if do_cache_depth_rect:
+                    self._depth_rect_cached = np.array(
+                        gt_group["depth_image_rect"],
+                        dtype=np.float32,
+                    )
+                else:
+                    self._depth_rect_lazy = _LazyH5Dataset(
+                        gt_hdf5_path,
+                        f"{gt_davis_key}/depth_image_rect",
+                        np.float32,
+                    )
+            else:
+                logger.warning("depth_image_rect not found in gt HDF5.")
+
+        if do_load_flow_h5:
+            if "flow_dist" in gt_group:
+                self._flow_h5_ts = np.array(gt_group["flow_dist_ts"], dtype=np.float64)
+                if do_cache_flow_h5:
+                    self._flow_h5_cached = np.array(gt_group["flow_dist"], dtype=np.float64)
+                else:
+                    self._flow_h5_lazy = _LazyH5Dataset(
+                        gt_hdf5_path,
+                        f"{gt_davis_key}/flow_dist",
+                        np.float64,
+                    )
+            else:
+                logger.warning("flow_dist not found in gt HDF5.")
+
+        if do_load_blended:
+            if "blended_image_rect" in gt_group:
+                self._blended_ts = np.array(gt_group["blended_image_rect_ts"], dtype=np.float64)
+                if do_cache_blended:
+                    self._blended_cached = np.array(
+                        gt_group["blended_image_rect"],
+                        dtype=np.uint8,
+                    )
+                else:
+                    self._blended_lazy = _LazyH5Dataset(
+                        gt_hdf5_path,
+                        f"{gt_davis_key}/blended_image_rect",
+                        np.uint8,
+                    )
+            else:
+                logger.warning("blended_image_rect not found in gt HDF5.")
+
+    # DataLoaderBase interface
+
+    def load_events(self, start_index: int, end_index: int) -> RawEvents:
+        """Load events in [start_index, end_index). Returns mutable copies."""
+        return self._event_backend.load_events(start_index, end_index)
+
+    @property
+    def num_events(self) -> int:
+        return self._event_backend.num_events
+
+    def time_to_index(self, t: float) -> int:
+        return self._event_backend.time_to_index(t)
+
+    def index_to_time(self, index: int) -> float:
+        return self._event_backend.index_to_time(index)
+
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        return self._event_backend.times_to_indices(timestamps)
+
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        return self._event_backend.indices_to_times(indices)
+
+    def close(self) -> None:
+        self._event_backend.close()
+        for reader in [
+            self._images_lazy,
+            self._velodyne_lazy,
+            self._depth_raw_lazy,
+            self._depth_rect_lazy,
+            self._flow_h5_lazy,
+            self._blended_lazy,
+        ]:
+            if reader is not None:
+                reader.close()
+
+    def __del__(self) -> None:
+        lazy_readers = [
+            getattr(self, attr, None)
+            for attr in (
+                "_images_lazy",
+                "_velodyne_lazy",
+                "_depth_raw_lazy",
+                "_depth_rect_lazy",
+                "_flow_h5_lazy",
+                "_blended_lazy",
+            )
+        ]
+        if any(r is not None and r.has_open_handle for r in lazy_readers):
+            warnings.warn(
+                f"MVSECDataLoader for '{self.sequence}' was not closed. "
+                "Call .close() or use a context manager to release HDF5 handles.",
+                ResourceWarning,
+                stacklevel=2,
+            )
+            self.close()
+
+    # GT optical flow (NPZ)
+
+    @property
+    def has_gt_flow(self) -> bool:
+        return self._gt_x_flow is not None
+
+    def load_optical_flow(self, t1: float, t2: float) -> npt.NDArray[np.float32]:
+        """Load GT optical flow between two timestamps.
+
+        Returns (H, W, 2) float32 where channels are [flow_x, flow_y].
+        Estimates displacement over [t1, t2) by propagating through GT frames.
+        """
+        if self._gt_x_flow is None or self._gt_y_flow is None or self._gt_ts is None:
+            raise RuntimeError("Ground truth flow not loaded.")
+
+        return _estimate_interval_flow(
+            self._gt_x_flow,
+            self._gt_y_flow,
+            self._gt_ts,
+            t1,
+            t2,
+        )
+
+    def get_gt_timestamps(self, event_index: int) -> Tuple[Optional[float], Optional[float]]:
+        """Return (t_before, t_after) GT timestamps bracketing event_index."""
+        if self._gt_ts is None:
+            return (None, None)
+
+        event_t = self.index_to_time(event_index)
+        ip = int(np.searchsorted(self._gt_ts, event_t, side="right"))
+
+        t_before = float(self._gt_ts[ip - 1]) if ip > 0 else None
+        t_after = float(self._gt_ts[ip]) if ip < len(self._gt_ts) else None
+
+        return (t_before, t_after)
+
+    def gt_time_list(self) -> npt.NDArray[np.float64]:
+        """Return all GT timestamps. Raises if GT flow not loaded."""
+        if self._gt_ts is None:
+            raise RuntimeError("Ground truth flow not loaded.")
+        return self._gt_ts
+
+    # Frames / images
+
+    @property
+    def frame_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._frame_ts
+
+    @property
+    def frame_event_indices(self) -> Optional[npt.NDArray[np.int64]]:
+        return self._frame_event_inds
+
+    @property
+    def event_load_mode(self) -> ResidentLoadMode:
+        return self._event_load_mode
+
+    @property
+    def image_load_mode(self) -> ResidentLoadMode:
+        return self._image_load_mode
+
+    @property
+    def has_images(self) -> bool:
+        return self._has_images
+
+    @property
+    def images(self) -> Optional[npt.NDArray[np.uint8]]:
+        """Precached images, or None if lazy/unavailable."""
+        return self._images
+
+    @property
+    def num_frames(self) -> int:
+        return len(self._frame_ts) if self._frame_ts is not None else 0
+
+    def normalize_frame_index(self, frame_index: int) -> int:
+        """Normalize negative index and validate bounds."""
+        n = self.num_frames
+        idx = frame_index
+        if idx < 0:
+            idx += n
+        if idx < 0 or idx >= n:
+            raise IndexError(f"Frame index {frame_index} out of range for dataset with {n} frames")
+        return idx
+
+    def find_nearest_frame_index(self, t: float) -> int:
+        if self._frame_ts is None or len(self._frame_ts) == 0:
+            raise RuntimeError("Frame timestamps are not available for this sequence.")
+        return _find_nearest_index(self._frame_ts, t)
+
+    def load_frame_sample(self, frame_index: int) -> dict[str, object]:
+        """Load a synchronized single camera MVSEC sample for one frame."""
+        idx = self.normalize_frame_index(frame_index)
+        if self._frame_ts is None:
+            raise RuntimeError("Frame timestamps are not available for this sequence.")
+
+        frame_t = float(self._frame_ts[idx])
+        if idx == 0:
+            start_t = float(self.index_to_time(0))
+        else:
+            start_t = float(self._frame_ts[idx - 1])
+
+        # use precomputed event indices when available
+        if self._frame_event_inds is not None:
+            ev_end = int(self._frame_event_inds[idx])
+            ev_start = 0 if idx == 0 else int(self._frame_event_inds[idx - 1])
+            events = self.load_events(ev_start, ev_end)
+        else:
+            events = self.get_events_by_time(start_t, frame_t)
+
+        image = self.load_image(idx)
+
+        flow = None
+        if self.has_gt_flow:
+            try:
+                flow = self.load_optical_flow(start_t, frame_t)
+            except ValueError:
+                flow = None
+
+        imu = None
+        if self.has_imu:
+            imu = self.load_imu(start_t, frame_t)
+
+        depth = None
+        if self.has_gt_depth_raw and self._depth_raw_ts is not None and len(self._depth_raw_ts) > 0:
+            depth = self.load_depth_raw(_find_nearest_index(self._depth_raw_ts, frame_t))
+
+        depth_rect = None
+        if (
+            self.has_gt_depth_rect
+            and self._depth_rect_ts is not None
+            and len(self._depth_rect_ts) > 0
+        ):
+            depth_rect = self.load_depth_rect(_find_nearest_index(self._depth_rect_ts, frame_t))
+
+        blended = None
+        if self.has_gt_blended and self._blended_ts is not None and len(self._blended_ts) > 0:
+            blended = self.load_blended_image(_find_nearest_index(self._blended_ts, frame_t))
+
+        velodyne = None
+        if self.has_velodyne and self._velodyne_ts is not None and len(self._velodyne_ts) > 0:
+            velodyne = self.load_velodyne_scan(_find_nearest_index(self._velodyne_ts, frame_t))
+
+        pose = None
+        if self.has_gt_pose:
+            pose = self.load_nearest_pose(frame_t, source="pose")
+
+        return {
+            "events": events,
+            "timestamp": frame_t,
+            "image": image,
+            "flow": flow,
+            "imu": imu,
+            "depth": depth,
+            "depth_rect": depth_rect,
+            "blended": blended,
+            "velodyne": velodyne,
+            "pose": pose,
+        }
+
+    def load_image(self, frame_index: int) -> Optional[npt.NDArray[np.uint8]]:
+        """Load a single grayscale frame by index."""
+        if self._images is not None:
+            return cast(npt.NDArray[np.uint8], self._images[frame_index])
+        if self._images_lazy is not None:
+            raw = self._images_lazy.read(frame_index)
+            if raw is None:
+                return None
+            arr = np.asarray(raw, dtype=np.uint8)
+            arr.flags.writeable = False
+            return arr
+        return None
+
+    # Calibration
+
+    @property
+    def has_calibration(self) -> bool:
+        return self._x_map is not None and self._y_map is not None
+
+    def undistort_events(self, events: RawEvents) -> RawEvents:
+        """Apply calibration rectification maps to events.
+
+        Returns new RawEvents with rectified coordinates.
+        Raises RuntimeError if calibration maps are not loaded.
+        """
+        if self._x_map is None or self._y_map is None:
+            raise RuntimeError("Calibration maps not loaded.")
+
+        h, w = self.IMAGE_SHAPE
+        cy = np.clip(events.y, 0, h - 1)
+        cx = np.clip(events.x, 0, w - 1)
+
+        return RawEvents(
+            x=np.round(self._x_map[cy, cx]).astype(np.int16),
+            y=np.round(self._y_map[cy, cx]).astype(np.int16),
+            timestamp=events.timestamp.copy(),
+            polarity=events.polarity.copy(),
+        )
+
+    # IMU
+
+    @property
+    def has_imu(self) -> bool:
+        return self._imu is not None
+
+    @property
+    def imu_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._imu_ts
+
+    @property
+    def imu_data(self) -> Optional[npt.NDArray[np.float64]]:
+        """Full IMU array (N, 6) [ax, ay, az, gx, gy, gz], or None."""
+        return self._imu
+
+    def load_imu(
+        self, t_start: float, t_end: float
+    ) -> Optional[Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
+        """Return IMU readings and timestamps in [t_start, t_end), or None."""
+        if self._imu is None or self._imu_ts is None:
+            return None
+
+        i0 = int(np.searchsorted(self._imu_ts, t_start, side="left"))
+        i1 = int(np.searchsorted(self._imu_ts, t_end, side="left"))
+        return (self._imu[i0:i1].copy(), self._imu_ts[i0:i1].copy())
+
+    # Odometry NPZ
+
+    @property
+    def has_odometry_npz(self) -> bool:
+        return self._odometry_npz is not None
+
+    @property
+    def odometry_npz(self) -> Optional[MVSECOdometryData]:
+        return self._odometry_npz
+
+    # GT odometry (LOAM SE(3))
+
+    @property
+    def has_gt_odometry(self) -> bool:
+        return self._gt_odometry is not None
+
+    @property
+    def gt_odometry(self) -> Optional[npt.NDArray[np.float64]]:
+        """LOAM odometry SE(3) poses (N, 4, 4), or None."""
+        return self._gt_odometry
+
+    @property
+    def gt_odometry_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._gt_odometry_ts
+
+    # GT pose (Cartographer SE(3))
+
+    @property
+    def has_gt_pose(self) -> bool:
+        return self._gt_pose is not None
+
+    @property
+    def gt_pose(self) -> Optional[npt.NDArray[np.float64]]:
+        """Cartographer SE(3) poses (N, 4, 4), or None."""
+        return self._gt_pose
+
+    @property
+    def gt_pose_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._gt_pose_ts
+
+    def load_nearest_pose(
+        self, t: float, source: str = "pose"
+    ) -> Optional[npt.NDArray[np.float64]]:
+        """Return the nearest SE(3) pose (4, 4) to time *t*.
+
+        Args:
+            t: Query timestamp.
+            source: ``"pose"`` for Cartographer or ``"odometry"`` for LOAM.
+        """
+        if source == "pose":
+            poses = self._gt_pose
+            ts = self._gt_pose_ts
+        elif source == "odometry":
+            poses = self._gt_odometry
+            ts = self._gt_odometry_ts
+        else:
+            raise ValueError(f"source must be 'pose' or 'odometry', got '{source}'")
+
+        if poses is None or ts is None:
+            return None
+        pose: npt.NDArray[np.float64] = poses[_find_nearest_index(ts, t)].copy()
+        return pose
+
+    # GT depth
+
+    @property
+    def has_gt_depth(self) -> bool:
+        return self.has_gt_depth_raw or self.has_gt_depth_rect
+
+    @property
+    def has_gt_depth_raw(self) -> bool:
+        return self._depth_raw_cached is not None or self._depth_raw_lazy is not None
+
+    @property
+    def has_gt_depth_rect(self) -> bool:
+        return self._depth_rect_cached is not None or self._depth_rect_lazy is not None
+
+    @property
+    def depth_raw_images(self) -> Optional[npt.NDArray[np.float32]]:
+        return self._depth_raw_cached
+
+    @property
+    def depth_rect_images(self) -> Optional[npt.NDArray[np.float32]]:
+        return self._depth_rect_cached
+
+    @property
+    def gt_depth_raw_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._depth_raw_ts
+
+    @property
+    def gt_depth_rect_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._depth_rect_ts
+
+    @property
+    def gt_depth_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self.gt_depth_raw_timestamps
+
+    @property
+    def num_gt_depth_raw_frames(self) -> int:
+        return len(self._depth_raw_ts) if self._depth_raw_ts is not None else 0
+
+    @property
+    def num_gt_depth_rect_frames(self) -> int:
+        return len(self._depth_rect_ts) if self._depth_rect_ts is not None else 0
+
+    @property
+    def num_gt_depth_frames(self) -> int:
+        if self._depth_raw_ts is not None:
+            return len(self._depth_raw_ts)
+        if self._depth_rect_ts is not None:
+            return len(self._depth_rect_ts)
+        return 0
+
+    def load_depth_raw(self, frame_index: int) -> Optional[npt.NDArray[np.float32]]:
+        return cast(
+            Optional[npt.NDArray[np.float32]],
+            self._read_large_frame(
+                self._depth_raw_cached, self._depth_raw_lazy, frame_index, np.float32
+            ),
+        )
+
+    def load_depth_rect(self, frame_index: int) -> Optional[npt.NDArray[np.float32]]:
+        return cast(
+            Optional[npt.NDArray[np.float32]],
+            self._read_large_frame(
+                self._depth_rect_cached, self._depth_rect_lazy, frame_index, np.float32
+            ),
+        )
+
+    def load_depth(
+        self, frame_index: int, rectified: bool = False
+    ) -> Optional[npt.NDArray[np.float32]]:
+        return self.load_depth_rect(frame_index) if rectified else self.load_depth_raw(frame_index)
+
+    # GT blended images
+
+    @property
+    def has_gt_blended(self) -> bool:
+        return self._blended_cached is not None or self._blended_lazy is not None
+
+    @property
+    def gt_blended_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._blended_ts
+
+    @property
+    def blended_images(self) -> Optional[npt.NDArray[np.uint8]]:
+        return self._blended_cached
+
+    def load_blended_image(self, frame_index: int) -> Optional[npt.NDArray[np.uint8]]:
+        return cast(
+            Optional[npt.NDArray[np.uint8]],
+            self._read_large_frame(self._blended_cached, self._blended_lazy, frame_index, np.uint8),
+        )
+
+    # GT flow from HDF5
+
+    @property
+    def has_gt_flow_hdf5(self) -> bool:
+        return self._flow_h5_cached is not None or self._flow_h5_lazy is not None
+
+    @property
+    def flow_hdf5_frames(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._flow_h5_cached
+
+    @property
+    def gt_flow_hdf5_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._flow_h5_ts
+
+    def load_flow_hdf5(self, frame_index: int) -> Optional[npt.NDArray[np.float64]]:
+        """Load a single flow field (2, H, W) float64 from gt HDF5."""
+        return cast(
+            Optional[npt.NDArray[np.float64]],
+            self._read_large_frame(
+                self._flow_h5_cached, self._flow_h5_lazy, frame_index, np.float64
+            ),
+        )
+
+    # Velodyne lidar
+
+    @property
+    def has_velodyne(self) -> bool:
+        return self._velodyne_cached is not None or self._velodyne_lazy is not None
+
+    @property
+    def velodyne_scans(self) -> Optional[npt.NDArray[np.float32]]:
+        return self._velodyne_cached
+
+    @property
+    def velodyne_timestamps(self) -> Optional[npt.NDArray[np.float64]]:
+        return self._velodyne_ts
+
+    @property
+    def num_velodyne_scans(self) -> int:
+        return len(self._velodyne_ts) if self._velodyne_ts is not None else 0
+
+    def load_velodyne_scan(self, scan_index: int) -> Optional[npt.NDArray[np.float32]]:
+        """Load a single velodyne scan (N_points, 4) [x, y, z, intensity]."""
+        return cast(
+            Optional[npt.NDArray[np.float32]],
+            self._read_large_frame(
+                self._velodyne_cached, self._velodyne_lazy, scan_index, np.float32
+            ),
+        )
+
+    # Shared lazy/cached dual path reader
+
+    @staticmethod
+    def _read_large_frame(
+        cached: "Optional[npt.NDArray[np.generic]]",
+        lazy: Optional[_LazyH5Dataset],
+        index: int,
+        dtype: type,
+    ) -> "Optional[npt.NDArray[np.generic]]":
+        if cached is not None:
+            frame: npt.NDArray[np.generic] = cached[index].copy()
+            return frame
+        if lazy is not None:
+            raw = lazy.read(index)
+            if raw is None:
+                return None
+            return np.asarray(raw, dtype=dtype)
+        return None

--- a/src/evlib/dataloaders/_mvsec.py
+++ b/src/evlib/dataloaders/_mvsec.py
@@ -21,10 +21,8 @@ import logging
 import os
 import warnings
 from typing import Dict
-from typing import Literal
 from typing import Optional
 from typing import Tuple
-from typing import Union
 from typing import cast
 
 import h5py
@@ -41,9 +39,10 @@ from ._event_cache import _LazyEventBackend
 from ._mvsec_storage import load_mvsec_gt_flow
 from ._mvsec_storage import resolve_mvsec_cache_dir
 from ._mvsec_types import MVSECOdometryData
+from ._storage_common import LoadingType
+from ._storage_common import LoadMode
 from ._storage_common import ResidentLoadMode
 from ._storage_common import _LazyH5Dataset
-from ._storage_common import normalize_resident_load_mode
 from .utils import find_nearest_index
 from .utils import get_flow_coordinate_grid
 from .utils import propagate_flow_step
@@ -51,29 +50,14 @@ from .utils import propagate_flow_step
 
 logger = logging.getLogger(__name__)
 
-# False = off, True/"lazy" = on demand, "cached" = in memory
-LoadMode = Union[bool, Literal["lazy", "cached"]]
-
-
-# Module lvl helpers
-
-
-def _resolve_load_mode(value: LoadMode) -> Tuple[bool, bool]:
-    """Parse a LoadMode into (should_load, should_cache)."""
-    if value is False:
-        return (False, False)
-    if value is True or value == "lazy":
-        return (True, False)
-    if value == "cached":
-        return (True, True)
-    raise ValueError(f"Invalid load mode: {value!r}. Expected False, True, 'lazy', or 'cached'.")
-
 
 def _resolve_depth_load_modes(
     load_gt_depth_raw: LoadMode,
     load_gt_depth_rect: LoadMode,
-) -> Tuple[Tuple[bool, bool], Tuple[bool, bool]]:
-    return _resolve_load_mode(load_gt_depth_raw), _resolve_load_mode(load_gt_depth_rect)
+) -> Tuple[LoadingType, LoadingType]:
+    raw_mode = LoadingType.from_value(load_gt_depth_raw, name="load_gt_depth_raw")
+    rect_mode = LoadingType.from_value(load_gt_depth_rect, name="load_gt_depth_rect")
+    return raw_mode, rect_mode
 
 
 def _load_calibration(
@@ -304,20 +288,24 @@ class MVSECDataLoader(DataLoaderBase):
             raise ValueError(f"camera must be 'left' or 'right', got '{camera}'")
         self.camera = camera
         has_explicit_cache = cache_dir is not None
-        self._event_load_mode = normalize_resident_load_mode("event_load_mode", event_load_mode)
-        self._image_load_mode = normalize_resident_load_mode("image_load_mode", image_load_mode)
+        self._event_load_mode = LoadingType.from_resident_value(
+            event_load_mode,
+            name="event_load_mode",
+        )
+        self._image_load_mode = LoadingType.from_resident_value(
+            image_load_mode,
+            name="image_load_mode",
+        )
         self._cache_dir = resolve_mvsec_cache_dir(cache_dir)
 
-        raw_depth_modes, rect_depth_modes = _resolve_depth_load_modes(
+        raw_depth_mode, rect_depth_mode = _resolve_depth_load_modes(
             load_gt_depth_raw,
             load_gt_depth_rect,
         )
-        do_load_gt_flow, do_cache_gt_flow = _resolve_load_mode(load_gt_flow)
-        do_load_depth_raw, do_cache_depth_raw = raw_depth_modes
-        do_load_depth_rect, do_cache_depth_rect = rect_depth_modes
-        do_load_flow_h5, do_cache_flow_h5 = _resolve_load_mode(load_gt_flow_hdf5)
-        do_load_blended, do_cache_blended = _resolve_load_mode(load_gt_blended)
-        do_load_velodyne, do_cache_velodyne = _resolve_load_mode(load_velodyne)
+        gt_flow_mode = LoadingType.from_value(load_gt_flow, name="load_gt_flow")
+        flow_h5_mode = LoadingType.from_value(load_gt_flow_hdf5, name="load_gt_flow_hdf5")
+        blended_mode = LoadingType.from_value(load_gt_blended, name="load_gt_blended")
+        velodyne_mode = LoadingType.from_value(load_velodyne, name="load_velodyne")
 
         hdf5_path = os.path.join(root, f"{sequence}_data.hdf5")
         self._data_hdf5_path = hdf5_path
@@ -328,7 +316,7 @@ class MVSECDataLoader(DataLoaderBase):
         npz_path = os.path.join(root, f"{sequence}_gt_flow_dist.npz")
         category = sequence.rstrip("0123456789")
 
-        has_gt_npz = do_load_gt_flow and os.path.isfile(npz_path)
+        has_gt_npz = gt_flow_mode.should_load and os.path.isfile(npz_path)
         odom_npz_path = os.path.join(root, f"{sequence}_odom.npz")
         has_odom_npz = load_odometry_npz and os.path.isfile(odom_npz_path)
 
@@ -365,7 +353,7 @@ class MVSECDataLoader(DataLoaderBase):
 
             # pick event backend - cached = all in RAM, lazy = sidecar mmap
             self._event_backend: _EventBackend
-            if self._event_load_mode == "cached":
+            if self._event_load_mode is LoadingType.CACHED:
                 if has_explicit_cache:
                     # try sidecar first, fallback direct HDF5 if broken
                     try:
@@ -397,7 +385,7 @@ class MVSECDataLoader(DataLoaderBase):
 
             self._has_images = "image_raw" in davis
             if self._has_images:
-                if self._image_load_mode == "cached":
+                if self._image_load_mode is LoadingType.CACHED:
                     self._images = np.array(davis["image_raw"], dtype=np.uint8)
                 else:
                     self._images_lazy = _LazyH5Dataset(
@@ -413,11 +401,11 @@ class MVSECDataLoader(DataLoaderBase):
                 else:
                     logger.warning("IMU data not found in %s", hdf5_path)
 
-            if do_load_velodyne:
+            if velodyne_mode.should_load:
                 if "velodyne" in data_h5 and "scans" in data_h5["velodyne"]:
                     vel = data_h5["velodyne"]
                     self._velodyne_ts = np.array(vel["scans_ts"], dtype=np.float64)
-                    if do_cache_velodyne:
+                    if velodyne_mode.should_cache:
                         self._velodyne_cached = np.array(vel["scans"], dtype=np.float32)
                     else:
                         self._velodyne_lazy = _LazyH5Dataset(
@@ -449,12 +437,12 @@ class MVSECDataLoader(DataLoaderBase):
         self._flow_h5_ts: Optional[npt.NDArray[np.float64]] = None
 
         needs_gt_h5 = (
-            do_load_depth_raw
-            or do_load_depth_rect
+            raw_depth_mode.should_load
+            or rect_depth_mode.should_load
             or load_gt_odometry
             or load_gt_poses
-            or do_load_flow_h5
-            or do_load_blended
+            or flow_h5_mode.should_load
+            or blended_mode.should_load
         )
         if needs_gt_h5 and os.path.isfile(gt_hdf5_path):
             with open_hdf5(gt_hdf5_path) as gt_h5:
@@ -469,14 +457,10 @@ class MVSECDataLoader(DataLoaderBase):
                         gt_group,
                         gt_hdf5_path,
                         gt_key,
-                        do_load_depth_raw,
-                        do_cache_depth_raw,
-                        do_load_depth_rect,
-                        do_cache_depth_rect,
-                        do_load_flow_h5,
-                        do_cache_flow_h5,
-                        do_load_blended,
-                        do_cache_blended,
+                        raw_depth_mode,
+                        rect_depth_mode,
+                        flow_h5_mode,
+                        blended_mode,
                     )
         elif needs_gt_h5:
             logger.warning("GT HDF5 file not found: %s", gt_hdf5_path)
@@ -485,14 +469,14 @@ class MVSECDataLoader(DataLoaderBase):
         self._gt_y_flow: Optional[npt.NDArray[np.float32]] = None
         self._gt_ts: Optional[npt.NDArray[np.float64]] = None
         if has_gt_npz:
-            mode: ResidentLoadMode = "cached" if do_cache_gt_flow else "lazy"
+            mode = LoadingType.CACHED if gt_flow_mode.should_cache else LoadingType.LAZY
             self._gt_x_flow, self._gt_y_flow, self._gt_ts = load_mvsec_gt_flow(
                 npz_path,
                 sequence,
                 self._cache_dir,
                 mode,
             )
-        elif do_load_gt_flow:
+        elif gt_flow_mode.should_load:
             logger.warning("GT flow file not found: %s", npz_path)
 
         self._x_map: Optional[npt.NDArray[np.float64]] = None
@@ -582,20 +566,16 @@ class MVSECDataLoader(DataLoaderBase):
         gt_group: h5py.Group,
         gt_hdf5_path: str,
         gt_davis_key: str,
-        do_load_depth_raw: bool,
-        do_cache_depth_raw: bool,
-        do_load_depth_rect: bool,
-        do_cache_depth_rect: bool,
-        do_load_flow_h5: bool,
-        do_cache_flow_h5: bool,
-        do_load_blended: bool,
-        do_cache_blended: bool,
+        raw_depth_mode: LoadingType,
+        rect_depth_mode: LoadingType,
+        flow_h5_mode: LoadingType,
+        blended_mode: LoadingType,
     ) -> None:
         """Load or set up lazy refs for large GT datasets."""
-        if do_load_depth_raw:
+        if raw_depth_mode.should_load:
             if "depth_image_raw" in gt_group:
                 self._depth_raw_ts = np.array(gt_group["depth_image_raw_ts"], dtype=np.float64)
-                if do_cache_depth_raw:
+                if raw_depth_mode.should_cache:
                     self._depth_raw_cached = np.array(gt_group["depth_image_raw"], dtype=np.float32)
                 else:
                     self._depth_raw_lazy = _LazyH5Dataset(
@@ -606,10 +586,10 @@ class MVSECDataLoader(DataLoaderBase):
             else:
                 logger.warning("depth_image_raw not found in gt HDF5.")
 
-        if do_load_depth_rect:
+        if rect_depth_mode.should_load:
             if "depth_image_rect" in gt_group:
                 self._depth_rect_ts = np.array(gt_group["depth_image_rect_ts"], dtype=np.float64)
-                if do_cache_depth_rect:
+                if rect_depth_mode.should_cache:
                     self._depth_rect_cached = np.array(
                         gt_group["depth_image_rect"],
                         dtype=np.float32,
@@ -623,10 +603,10 @@ class MVSECDataLoader(DataLoaderBase):
             else:
                 logger.warning("depth_image_rect not found in gt HDF5.")
 
-        if do_load_flow_h5:
+        if flow_h5_mode.should_load:
             if "flow_dist" in gt_group:
                 self._flow_h5_ts = np.array(gt_group["flow_dist_ts"], dtype=np.float64)
-                if do_cache_flow_h5:
+                if flow_h5_mode.should_cache:
                     self._flow_h5_cached = np.array(gt_group["flow_dist"], dtype=np.float64)
                 else:
                     self._flow_h5_lazy = _LazyH5Dataset(
@@ -637,10 +617,10 @@ class MVSECDataLoader(DataLoaderBase):
             else:
                 logger.warning("flow_dist not found in gt HDF5.")
 
-        if do_load_blended:
+        if blended_mode.should_load:
             if "blended_image_rect" in gt_group:
                 self._blended_ts = np.array(gt_group["blended_image_rect_ts"], dtype=np.float64)
-                if do_cache_blended:
+                if blended_mode.should_cache:
                     self._blended_cached = np.array(
                         gt_group["blended_image_rect"],
                         dtype=np.uint8,
@@ -763,11 +743,11 @@ class MVSECDataLoader(DataLoaderBase):
         return self._frame_event_inds
 
     @property
-    def event_load_mode(self) -> ResidentLoadMode:
+    def event_load_mode(self) -> LoadingType:
         return self._event_load_mode
 
     @property
-    def image_load_mode(self) -> ResidentLoadMode:
+    def image_load_mode(self) -> LoadingType:
         return self._image_load_mode
 
     @property

--- a/src/evlib/dataloaders/_mvsec.py
+++ b/src/evlib/dataloaders/_mvsec.py
@@ -14,41 +14,37 @@ The Multi Vehicle Stereo Event Camera Dataset: An Event Camera Dataset for 3D Pe
 IEEE Robotics and Automation Letters, 3(3), 2032-2039.
 """
 
-from __future__ import annotations
-
 import concurrent.futures
 import logging
 import os
 import warnings
-from functools import lru_cache
-from typing import Any, Dict, Literal, Optional, Tuple, Union, cast
+from typing import Dict
+from typing import Literal
+from typing import Optional
+from typing import Tuple
+from typing import Union
+from typing import cast
 
 import h5py
 import numpy as np
 import numpy.typing as npt
 
-_cv2: Any = None
-
-try:
-    import cv2 as _cv2
-except ImportError:
-    _cv2 = None
-
-cv2: Any = _cv2
-
 from evlib.codec.fileformat.hdf5 import open_hdf5
 from evlib.types import RawEvents
 
 from ._base import DataLoaderBase
-from ._mvsec_storage import _CachedEventBackend
-from ._mvsec_storage import _EventBackend
-from ._mvsec_storage import _LazyEventBackend
-from ._mvsec_storage import _LazyH5Dataset
-from ._mvsec_storage import ResidentLoadMode
+from ._event_cache import _CachedEventBackend
+from ._event_cache import _EventBackend
+from ._event_cache import _LazyEventBackend
 from ._mvsec_storage import load_mvsec_gt_flow
-from ._mvsec_storage import normalize_resident_load_mode
 from ._mvsec_storage import resolve_mvsec_cache_dir
 from ._mvsec_types import MVSECOdometryData
+from ._storage_common import ResidentLoadMode
+from ._storage_common import _LazyH5Dataset
+from ._storage_common import normalize_resident_load_mode
+from .utils import find_nearest_index
+from .utils import get_flow_coordinate_grid
+from .utils import propagate_flow_step
 
 
 logger = logging.getLogger(__name__)
@@ -103,120 +99,6 @@ def _load_odometry_npz(npz_path: str) -> Optional[MVSECOdometryData]:
     )
 
 
-def _find_nearest_index(timestamps: npt.NDArray[np.float64], t: float) -> int:
-    """Index of the timestamp nearest to *t*."""
-    idx = int(np.searchsorted(timestamps, t, side="left"))
-
-    if idx >= len(timestamps):
-        return len(timestamps) - 1
-    if idx == 0:
-        return 0
-
-    left_dist = abs(t - timestamps[idx - 1])
-    right_dist = abs(t - timestamps[idx])
-    return idx - 1 if left_dist <= right_dist else idx
-
-
-@lru_cache(maxsize=8)
-def _get_flow_coordinate_grid(
-    h: int,
-    w: int,
-) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
-    """Cached base coordinate grids for dense flow propagation."""
-    xc, yc = np.meshgrid(
-        np.arange(w, dtype=np.float32),
-        np.arange(h, dtype=np.float32),
-        indexing="xy",
-    )
-    xc.flags.writeable = False
-    yc.flags.writeable = False
-    return xc, yc
-
-
-def _sample_flow_nearest_numpy(
-    x_flow: npt.NDArray[np.float32],
-    y_flow: npt.NDArray[np.float32],
-    x_coords: npt.NDArray[np.float32],
-    y_coords: npt.NDArray[np.float32],
-) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
-    """Pure numpy fallback for nearest neighbor flow sampling."""
-    rx = np.rint(x_coords).astype(np.int32)
-    ry = np.rint(y_coords).astype(np.int32)
-
-    h, w = x_flow.shape
-    valid = (rx >= 0) & (rx < w) & (ry >= 0) & (ry < h)
-
-    sx = np.zeros_like(x_flow, dtype=np.float32)
-    sy = np.zeros_like(y_flow, dtype=np.float32)
-    if np.any(valid):
-        sx[valid] = x_flow[ry[valid], rx[valid]]
-        sy[valid] = y_flow[ry[valid], rx[valid]]
-
-    return sx, sy, valid
-
-
-def _sample_flow_nearest(
-    x_flow: npt.NDArray[np.float32],
-    y_flow: npt.NDArray[np.float32],
-    x_coords: npt.NDArray[np.float32],
-    y_coords: npt.NDArray[np.float32],
-) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
-    """Sample dense flow at floating point coordinates, opencv if available."""
-    rx = np.rint(x_coords).astype(np.int32)
-    ry = np.rint(y_coords).astype(np.int32)
-
-    h, w = x_flow.shape
-    valid = (rx >= 0) & (rx < w) & (ry >= 0) & (ry < h)
-
-    if cv2 is None:
-        return _sample_flow_nearest_numpy(x_flow, y_flow, x_coords, y_coords)
-
-    sx = np.asarray(
-        cv2.remap(
-            x_flow,
-            x_coords,
-            y_coords,
-            interpolation=cv2.INTER_NEAREST,
-            borderMode=cv2.BORDER_CONSTANT,
-            borderValue=0,
-        ),
-        dtype=np.float32,
-    )
-    sy = np.asarray(
-        cv2.remap(
-            y_flow,
-            x_coords,
-            y_coords,
-            interpolation=cv2.INTER_NEAREST,
-            borderMode=cv2.BORDER_CONSTANT,
-            borderValue=0,
-        ),
-        dtype=np.float32,
-    )
-    return sx, sy, valid
-
-
-def _propagate_flow_step(
-    x_flow: npt.NDArray[np.float32],
-    y_flow: npt.NDArray[np.float32],
-    x_coords: npt.NDArray[np.float32],
-    y_coords: npt.NDArray[np.float32],
-    x_mask: npt.NDArray[np.bool_],
-    y_mask: npt.NDArray[np.bool_],
-    scale: float,
-) -> None:
-    """Propagate pixel coordinates through one GT flow field (in place)."""
-    sx, sy, valid = _sample_flow_nearest(x_flow, y_flow, x_coords, y_coords)
-
-    x_mask &= valid
-    y_mask &= valid
-    x_mask[sx == 0.0] = False
-    y_mask[sy == 0.0] = False
-
-    x_coords += sx * scale
-    y_coords += sy * scale
-
-
 def _estimate_interval_flow(
     x_flow_all: npt.NDArray[np.float32],
     y_flow_all: npt.NDArray[np.float32],
@@ -268,14 +150,14 @@ def _estimate_interval_flow(
     # slow path - walk pixel coords through multiple GT intervals
     # leading partial -> full middle intervals -> trailing partial
     h, w = x_flow_all.shape[1], x_flow_all.shape[2]
-    origin_x, origin_y = _get_flow_coordinate_grid(h, w)
+    origin_x, origin_y = get_flow_coordinate_grid(h, w)
     xc = origin_x.copy()
     yc = origin_y.copy()
     xm = np.ones((h, w), dtype=np.bool_)
     ym = np.ones((h, w), dtype=np.bool_)
 
     # leading partial
-    _propagate_flow_step(
+    propagate_flow_step(
         x_flow_all[start_idx],
         y_flow_all[start_idx],
         xc,
@@ -290,7 +172,7 @@ def _estimate_interval_flow(
     while i < last_flow_idx:
         if float(gt_timestamps[i + 1]) >= t_end:
             break
-        _propagate_flow_step(
+        propagate_flow_step(
             x_flow_all[i],
             y_flow_all[i],
             xc,
@@ -305,7 +187,7 @@ def _estimate_interval_flow(
     trail_t0 = float(gt_timestamps[i])
     trail_t1 = float(gt_timestamps[i + 1])
     trail_scale = (t_end - trail_t0) / (trail_t1 - trail_t0)
-    _propagate_flow_step(
+    propagate_flow_step(
         x_flow_all[i],
         y_flow_all[i],
         xc,
@@ -439,6 +321,7 @@ class MVSECDataLoader(DataLoaderBase):
         self._data_hdf5_path = hdf5_path
         davis_key = f"davis/{camera}"
         self._davis_key = davis_key
+        event_cache_name = f"{sequence}_{camera}"
 
         npz_path = os.path.join(root, f"{sequence}_gt_flow_dist.npz")
         category = sequence.rstrip("0123456789")
@@ -487,8 +370,7 @@ class MVSECDataLoader(DataLoaderBase):
                         self._event_backend = _CachedEventBackend.from_sidecar(
                             source_path=hdf5_path,
                             dataset_key=f"{davis_key}/events",
-                            sequence=sequence,
-                            camera=camera,
+                            cache_name=event_cache_name,
                             cache_root=self._cache_dir,
                         )
                     except OSError:
@@ -501,8 +383,7 @@ class MVSECDataLoader(DataLoaderBase):
                 self._event_backend = _LazyEventBackend(
                     source_path=hdf5_path,
                     dataset_key=f"{davis_key}/events",
-                    sequence=sequence,
-                    camera=camera,
+                    cache_name=event_cache_name,
                     cache_root=self._cache_dir,
                 )
 
@@ -913,7 +794,7 @@ class MVSECDataLoader(DataLoaderBase):
     def find_nearest_frame_index(self, t: float) -> int:
         if self._frame_ts is None or len(self._frame_ts) == 0:
             raise RuntimeError("Frame timestamps are not available for this sequence.")
-        return _find_nearest_index(self._frame_ts, t)
+        return find_nearest_index(self._frame_ts, t)
 
     def load_frame_sample(self, frame_index: int) -> dict[str, object]:
         """Load a synchronized single camera MVSEC sample for one frame."""
@@ -950,7 +831,7 @@ class MVSECDataLoader(DataLoaderBase):
 
         depth = None
         if self.has_gt_depth_raw and self._depth_raw_ts is not None and len(self._depth_raw_ts) > 0:
-            depth = self.load_depth_raw(_find_nearest_index(self._depth_raw_ts, frame_t))
+            depth = self.load_depth_raw(find_nearest_index(self._depth_raw_ts, frame_t))
 
         depth_rect = None
         if (
@@ -958,15 +839,15 @@ class MVSECDataLoader(DataLoaderBase):
             and self._depth_rect_ts is not None
             and len(self._depth_rect_ts) > 0
         ):
-            depth_rect = self.load_depth_rect(_find_nearest_index(self._depth_rect_ts, frame_t))
+            depth_rect = self.load_depth_rect(find_nearest_index(self._depth_rect_ts, frame_t))
 
         blended = None
         if self.has_gt_blended and self._blended_ts is not None and len(self._blended_ts) > 0:
-            blended = self.load_blended_image(_find_nearest_index(self._blended_ts, frame_t))
+            blended = self.load_blended_image(find_nearest_index(self._blended_ts, frame_t))
 
         velodyne = None
         if self.has_velodyne and self._velodyne_ts is not None and len(self._velodyne_ts) > 0:
-            velodyne = self.load_velodyne_scan(_find_nearest_index(self._velodyne_ts, frame_t))
+            velodyne = self.load_velodyne_scan(find_nearest_index(self._velodyne_ts, frame_t))
 
         pose = None
         if self.has_gt_pose:
@@ -999,6 +880,10 @@ class MVSECDataLoader(DataLoaderBase):
         return None
 
     # Calibration
+
+    @property
+    def valid_frame_range(self) -> Optional[Tuple[int, Optional[int]]]:
+        return self.VALID_FRAMES.get(self.sequence)
 
     @property
     def has_calibration(self) -> bool:
@@ -1110,7 +995,7 @@ class MVSECDataLoader(DataLoaderBase):
 
         if poses is None or ts is None:
             return None
-        pose: npt.NDArray[np.float64] = poses[_find_nearest_index(ts, t)].copy()
+        pose: npt.NDArray[np.float64] = poses[find_nearest_index(ts, t)].copy()
         return pose
 
     # GT depth

--- a/src/evlib/dataloaders/_mvsec_storage.py
+++ b/src/evlib/dataloaders/_mvsec_storage.py
@@ -1,5 +1,7 @@
 """MVSEC storage helpers and GT flow sidecar cache."""
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/src/evlib/dataloaders/_mvsec_storage.py
+++ b/src/evlib/dataloaders/_mvsec_storage.py
@@ -1,8 +1,5 @@
-"""Private storage backends for MVSEC loader internals."""
+"""MVSEC storage helpers and GT flow sidecar cache."""
 
-from __future__ import annotations
-
-import abc
 import hashlib
 import json
 import os
@@ -11,33 +8,15 @@ import uuid
 from typing import Literal
 from typing import Optional
 from typing import TypedDict
-from typing import Union
 from typing import cast
 
-import h5py
 import numpy as np
 import numpy.typing as npt
-from numpy.lib.format import open_memmap
 
-from evlib.codec.fileformat.hdf5 import open_hdf5
-from evlib.types import RawEvents
+from ._storage_common import ResidentLoadMode
 
 
-ResidentLoadMode = Literal["cached", "lazy"]
-
-# bump these when the on disk sidecar format changes
-_EVENT_CACHE_SCHEMA_VERSION = 1
-_EVENT_BUILD_BLOCK_ROWS = 1_000_000  # keep peak memory bounded during HDF5 reads
 _GT_FLOW_CACHE_SCHEMA_VERSION = 1
-
-
-class _EventCacheMetadata(TypedDict):
-    schema_version: int
-    source_path: str
-    dataset_key: str
-    source_size: int
-    source_mtime_ns: int
-    num_events: int
 
 
 class _GTFlowCacheMetadata(TypedDict):
@@ -47,75 +26,22 @@ class _GTFlowCacheMetadata(TypedDict):
     source_mtime_ns: int
 
 
-def normalize_resident_load_mode(name: str, value: str) -> ResidentLoadMode:
-    if value not in ("cached", "lazy"):
-        raise ValueError(f"{name} must be 'cached' or 'lazy', got {value!r}")
-    return cast(ResidentLoadMode, value)
-
-
 def resolve_mvsec_cache_dir(cache_dir: Optional[str]) -> str:
-    """Resolve per user MVSEC cache directory.
-
-    Falls back to ``$XDG_CACHE_HOME/evlib/mvsec`` or ``~/.cache/evlib/mvsec``.
-    """
+    """MVSEC cache root directory."""
     if cache_dir is not None:
-        return os.path.abspath(os.path.expanduser(cache_dir))
+        expanded_path = os.path.expanduser(cache_dir)
+        absolute_path = os.path.abspath(expanded_path)
+        return absolute_path
 
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    if xdg is not None:
-        base = os.path.expanduser(xdg)
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home is not None:
+        cache_base = os.path.expanduser(xdg_cache_home)
     else:
-        base = os.path.join(os.path.expanduser("~"), ".cache")
+        home_dir = os.path.expanduser("~")
+        cache_base = os.path.join(home_dir, ".cache")
 
-    return os.path.abspath(os.path.join(base, "evlib", "mvsec"))
-
-
-# Cache signatures and paths
-
-
-def _make_cache_signature(
-    source_path: str,
-    dataset_key: str,
-    source_size: int,
-    source_mtime_ns: int,
-) -> str:
-    """Content addressed hash so a changed source file gets a fresh sidecar."""
-    parts = [
-        os.path.abspath(source_path),
-        dataset_key,
-        str(source_size),
-        str(source_mtime_ns),
-        str(_EVENT_CACHE_SCHEMA_VERSION),
-    ]
-    return hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()
-
-
-def _make_event_cache_dir(
-    cache_root: str,
-    source_path: str,
-    dataset_key: str,
-    sequence: str,
-    camera: str,
-) -> str:
-    stat = os.stat(source_path)
-    sig = _make_cache_signature(
-        source_path,
-        dataset_key,
-        int(stat.st_size),
-        int(stat.st_mtime_ns),
-    )
-    name = f"{sequence}_{camera}_{sig[:16]}"
-    return os.path.join(cache_root, "event_sidecars", name)
-
-
-def _make_event_cache_paths(cache_dir: str) -> dict:
-    return {
-        "x": os.path.join(cache_dir, "events_x.npy"),
-        "y": os.path.join(cache_dir, "events_y.npy"),
-        "timestamp": os.path.join(cache_dir, "events_t.npy"),
-        "polarity": os.path.join(cache_dir, "events_p.npy"),
-        "metadata": os.path.join(cache_dir, "metadata.json"),
-    }
+    cache_dir_path = os.path.join(cache_base, "evlib", "mvsec")
+    return os.path.abspath(cache_dir_path)
 
 
 def _make_gt_flow_cache_dir(
@@ -123,15 +49,17 @@ def _make_gt_flow_cache_dir(
     source_path: str,
     sequence: str,
 ) -> str:
-    stat = os.stat(source_path)
+    stat_result = os.stat(source_path)
     parts = [
         os.path.abspath(source_path),
-        str(int(stat.st_size)),
-        str(int(stat.st_mtime_ns)),
+        str(int(stat_result.st_size)),
+        str(int(stat_result.st_mtime_ns)),
         str(_GT_FLOW_CACHE_SCHEMA_VERSION),
     ]
-    sig = hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()
-    return os.path.join(cache_root, "gt_flow_sidecars", f"{sequence}_{sig[:16]}")
+    joined = "|".join(parts)
+    signature = hashlib.sha1(joined.encode("utf-8")).hexdigest()
+    directory_name = f"{sequence}_{signature[:16]}"
+    return os.path.join(cache_root, "gt_flow_sidecars", directory_name)
 
 
 def _make_gt_flow_cache_paths(cache_dir: str) -> dict[str, str]:
@@ -143,54 +71,18 @@ def _make_gt_flow_cache_paths(cache_dir: str) -> dict[str, str]:
     }
 
 
-def _write_json(path: str, data: Union[_EventCacheMetadata, _GTFlowCacheMetadata]) -> None:
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, sort_keys=True)
-
-
-# Cache metadata and staleness checks
-
-
-def _load_event_cache_metadata(metadata_path: str) -> Optional[_EventCacheMetadata]:
-    if not os.path.isfile(metadata_path):
-        return None
-    with open(metadata_path, "r", encoding="utf-8") as f:
-        return cast(_EventCacheMetadata, json.load(f))
+def _write_json(path: str, data: _GTFlowCacheMetadata) -> None:
+    with open(path, "w", encoding="utf-8") as file_handle:
+        json.dump(data, file_handle, indent=2, sort_keys=True)
 
 
 def _load_gt_flow_cache_metadata(metadata_path: str) -> Optional[_GTFlowCacheMetadata]:
     if not os.path.isfile(metadata_path):
         return None
-    with open(metadata_path, "r", encoding="utf-8") as f:
-        return cast(_GTFlowCacheMetadata, json.load(f))
 
-
-def _event_cache_is_complete(
-    cache_dir: str,
-    source_path: str,
-    dataset_key: str,
-) -> Optional[_EventCacheMetadata]:
-    """Return metadata if the sidecar is complete and still matches the source file."""
-    paths = _make_event_cache_paths(cache_dir)
-    meta = _load_event_cache_metadata(paths["metadata"])
-    if meta is None:
-        return None
-
-    if not all(os.path.isfile(paths[k]) for k in ("x", "y", "timestamp", "polarity")):
-        return None
-
-    # staleness - size + mtime, not content hash (good enough, and fast)
-    stat = os.stat(source_path)
-    if (
-        meta["schema_version"] != _EVENT_CACHE_SCHEMA_VERSION
-        or meta["source_path"] != os.path.abspath(source_path)
-        or meta["dataset_key"] != dataset_key
-        or meta["source_size"] != int(stat.st_size)
-        or meta["source_mtime_ns"] != int(stat.st_mtime_ns)
-    ):
-        return None
-
-    return meta
+    with open(metadata_path, "r", encoding="utf-8") as file_handle:
+        metadata = cast(_GTFlowCacheMetadata, json.load(file_handle))
+    return metadata
 
 
 def _gt_flow_cache_is_complete(
@@ -198,219 +90,80 @@ def _gt_flow_cache_is_complete(
     source_path: str,
 ) -> Optional[_GTFlowCacheMetadata]:
     paths = _make_gt_flow_cache_paths(cache_dir)
-    meta = _load_gt_flow_cache_metadata(paths["metadata"])
-    if meta is None:
+    metadata = _load_gt_flow_cache_metadata(paths["metadata"])
+    if metadata is None:
         return None
 
-    if not all(os.path.isfile(paths[k]) for k in ("x", "y", "timestamp")):
+    required_keys = ("x", "y", "timestamp")
+    if not all(os.path.isfile(paths[key]) for key in required_keys):
         return None
 
-    stat = os.stat(source_path)
-    if (
-        meta["schema_version"] != _GT_FLOW_CACHE_SCHEMA_VERSION
-        or meta["source_path"] != os.path.abspath(source_path)
-        or meta["source_size"] != int(stat.st_size)
-        or meta["source_mtime_ns"] != int(stat.st_mtime_ns)
-    ):
+    stat_result = os.stat(source_path)
+    source_size = int(stat_result.st_size)
+    source_mtime_ns = int(stat_result.st_mtime_ns)
+    source_path_abs = os.path.abspath(source_path)
+    is_stale = (
+        metadata["schema_version"] != _GT_FLOW_CACHE_SCHEMA_VERSION
+        or metadata["source_path"] != source_path_abs
+        or metadata["source_size"] != source_size
+        or metadata["source_mtime_ns"] != source_mtime_ns
+    )
+    if is_stale:
         return None
 
-    return meta
-
-
-# Building sidecars
-
-# Both builders use the same pattern - write into a uuid temp dir then
-# atomic os.replace into the real path, readers never see half written files
-
-# TODO: no file lock, concurrent builds of the same sidecar will race but
-# the last os.replace wins and the result is still valid.
-
-
-def _copy_event_rows_into_columns(
-    event_dataset: h5py.Dataset,
-    x_values: npt.NDArray[np.int16],
-    y_values: npt.NDArray[np.int16],
-    timestamp_values: npt.NDArray[np.float64],
-    polarity_values: npt.NDArray[np.bool_],
-) -> None:
-    """Blockwise HDF5 read into pre allocated typed columns.
-
-    MVSEC stores events as (N, 4) float64 rows. Streaming in fixed blocks
-    avoids loading the full table into memory for large sequences.
-    """
-    n = int(event_dataset.shape[0])
-    buf = np.empty((_EVENT_BUILD_BLOCK_ROWS, 4), dtype=np.float64)
-    start = 0
-
-    while start < n:
-        end = min(start + _EVENT_BUILD_BLOCK_ROWS, n)
-        block = buf[: end - start]
-        event_dataset.read_direct(block, source_sel=np.s_[start:end, :])
-
-        x_values[start:end] = block[:, 0]
-        y_values[start:end] = block[:, 1]
-        timestamp_values[start:end] = block[:, 2]
-        # MVSEC pol is +1/-1 float, convert to bool
-        np.greater(block[:, 3], 0.0, out=polarity_values[start:end])
-
-        start = end
-
-
-def _freeze_event_columns(
-    x_values: npt.NDArray[np.int16],
-    y_values: npt.NDArray[np.int16],
-    timestamp_values: npt.NDArray[np.float64],
-    polarity_values: npt.NDArray[np.bool_],
-) -> None:
-    for arr in (x_values, y_values, timestamp_values, polarity_values):
-        arr.flags.writeable = False
-
-
-def _build_event_cache(
-    source_path: str,
-    dataset_key: str,
-    cache_dir: str,
-) -> _EventCacheMetadata:
-    """Build typed npy sidecar from the HDF5 events table."""
-    parent = os.path.dirname(cache_dir)
-    os.makedirs(parent, exist_ok=True)
-
-    tmp = os.path.join(parent, f".tmp_{uuid.uuid4().hex}")
-    if os.path.isdir(tmp):
-        shutil.rmtree(tmp)
-    os.makedirs(tmp, exist_ok=True)
-
-    paths = _make_event_cache_paths(tmp)
-
-    try:
-        with open_hdf5(source_path) as h5:
-            ds = h5[dataset_key]
-            n = int(ds.shape[0])
-
-            x = open_memmap(paths["x"], mode="w+", dtype=np.int16, shape=(n,))
-            y = open_memmap(paths["y"], mode="w+", dtype=np.int16, shape=(n,))
-            t = open_memmap(paths["timestamp"], mode="w+", dtype=np.float64, shape=(n,))
-            p = open_memmap(paths["polarity"], mode="w+", dtype=np.bool_, shape=(n,))
-
-            _copy_event_rows_into_columns(ds, x, y, t, p)
-
-            x.flush()
-            y.flush()
-            t.flush()
-            p.flush()
-
-        stat = os.stat(source_path)
-        meta: _EventCacheMetadata = {
-            "schema_version": _EVENT_CACHE_SCHEMA_VERSION,
-            "source_path": os.path.abspath(source_path),
-            "dataset_key": dataset_key,
-            "source_size": int(stat.st_size),
-            "source_mtime_ns": int(stat.st_mtime_ns),
-            "num_events": n,
-        }
-        _write_json(paths["metadata"], meta)
-
-        if os.path.isdir(cache_dir):
-            shutil.rmtree(cache_dir)
-        os.replace(tmp, cache_dir)
-        return meta
-    except Exception:
-        shutil.rmtree(tmp, ignore_errors=True)
-        raise
+    return metadata
 
 
 def _build_gt_flow_cache(
     source_path: str,
     cache_dir: str,
 ) -> _GTFlowCacheMetadata:
-    parent = os.path.dirname(cache_dir)
-    os.makedirs(parent, exist_ok=True)
+    parent_dir = os.path.dirname(cache_dir)
+    os.makedirs(parent_dir, exist_ok=True)
 
-    tmp = os.path.join(parent, f".tmp_{uuid.uuid4().hex}")
-    if os.path.isdir(tmp):
-        shutil.rmtree(tmp)
-    os.makedirs(tmp, exist_ok=True)
+    temp_dir = os.path.join(parent_dir, f".tmp_{uuid.uuid4().hex}")
+    if os.path.isdir(temp_dir):
+        shutil.rmtree(temp_dir)
+    os.makedirs(temp_dir, exist_ok=True)
 
-    paths = _make_gt_flow_cache_paths(tmp)
+    paths = _make_gt_flow_cache_paths(temp_dir)
 
     try:
-        with np.load(source_path) as npz:
-            x_flow = np.asarray(npz["x_flow_dist"], dtype=np.float32)
-            y_flow = np.asarray(npz["y_flow_dist"], dtype=np.float32)
-            timestamps = np.asarray(npz["timestamps"], dtype=np.float64)
+        with np.load(source_path) as npz_file:
+            x_flow = np.asarray(npz_file["x_flow_dist"], dtype=np.float32)
+            y_flow = np.asarray(npz_file["y_flow_dist"], dtype=np.float32)
+            timestamps = np.asarray(npz_file["timestamps"], dtype=np.float64)
 
         np.save(paths["x"], x_flow)
         np.save(paths["y"], y_flow)
         np.save(paths["timestamp"], timestamps)
 
-        stat = os.stat(source_path)
-        meta: _GTFlowCacheMetadata = {
+        stat_result = os.stat(source_path)
+        metadata: _GTFlowCacheMetadata = {
             "schema_version": _GT_FLOW_CACHE_SCHEMA_VERSION,
             "source_path": os.path.abspath(source_path),
-            "source_size": int(stat.st_size),
-            "source_mtime_ns": int(stat.st_mtime_ns),
+            "source_size": int(stat_result.st_size),
+            "source_mtime_ns": int(stat_result.st_mtime_ns),
         }
-        _write_json(paths["metadata"], meta)
+        _write_json(paths["metadata"], metadata)
 
         if os.path.isdir(cache_dir):
             shutil.rmtree(cache_dir)
-        os.replace(tmp, cache_dir)
-        return meta
+        os.replace(temp_dir, cache_dir)
+        return metadata
     except Exception:
-        shutil.rmtree(tmp, ignore_errors=True)
+        shutil.rmtree(temp_dir, ignore_errors=True)
         raise
-
-
-# Loading from sidecars
-
-
-def _prepare_event_cache(
-    source_path: str,
-    dataset_key: str,
-    sequence: str,
-    camera: str,
-    cache_root: str,
-) -> tuple[str, dict[str, str], _EventCacheMetadata]:
-    """Ensure an event sidecar exists and return (cache_dir, paths, metadata)."""
-    src = os.path.abspath(source_path)
-    cache_dir = _make_event_cache_dir(cache_root, src, dataset_key, sequence, camera)
-    paths = _make_event_cache_paths(cache_dir)
-    meta = _event_cache_is_complete(cache_dir, src, dataset_key)
-    if meta is None:
-        meta = _build_event_cache(src, dataset_key, cache_dir)
-    return cache_dir, paths, meta
-
-
-def load_mvsec_cached_events(
-    source_path: str,
-    dataset_key: str,
-    sequence: str,
-    camera: str,
-    cache_root: str,
-) -> tuple[
-    npt.NDArray[np.int16],
-    npt.NDArray[np.int16],
-    npt.NDArray[np.float64],
-    npt.NDArray[np.bool_],
-]:
-    """Load event columns from a persistent sidecar into RAM (frozen)."""
-    _, paths, _ = _prepare_event_cache(source_path, dataset_key, sequence, camera, cache_root)
-    x = np.load(paths["x"])
-    y = np.load(paths["y"])
-    t = np.load(paths["timestamp"])
-    p = np.load(paths["polarity"])
-    _freeze_event_columns(x, y, t, p)
-    return x, y, t, p
 
 
 def _load_gt_flow_from_npz_file(
     source_path: str,
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float64]]:
-    with np.load(source_path) as npz:
-        x = np.asarray(npz["x_flow_dist"], dtype=np.float32)
-        y = np.asarray(npz["y_flow_dist"], dtype=np.float32)
-        ts = np.asarray(npz["timestamps"], dtype=np.float64)
-    return x, y, ts
+    with np.load(source_path) as npz_file:
+        x_flow = np.asarray(npz_file["x_flow_dist"], dtype=np.float32)
+        y_flow = np.asarray(npz_file["y_flow_dist"], dtype=np.float32)
+        timestamps = np.asarray(npz_file["timestamps"], dtype=np.float64)
+    return x_flow, y_flow, timestamps
 
 
 def load_mvsec_gt_flow(
@@ -419,19 +172,23 @@ def load_mvsec_gt_flow(
     cache_root: str,
     load_mode: ResidentLoadMode,
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float64]]:
-    """Load GT flow arrays, building a decompressed sidecar cache if needed."""
+    """Load MVSEC GT flow arrays, build a decompressed sidecar if needed."""
     try:
         cache_dir = _make_gt_flow_cache_dir(cache_root, source_path, sequence)
-        meta = _gt_flow_cache_is_complete(cache_dir, source_path)
-        if meta is None:
-            meta = _build_gt_flow_cache(source_path, cache_dir)
+        metadata = _gt_flow_cache_is_complete(cache_dir, source_path)
+        if metadata is None:
+            metadata = _build_gt_flow_cache(source_path, cache_dir)
 
         paths = _make_gt_flow_cache_paths(cache_dir)
-        mmap: Optional[Literal["r"]] = "r" if load_mode == "lazy" else None
+        mmap_mode: Optional[Literal["r"]]
+        if load_mode == "lazy":
+            mmap_mode = "r"
+        else:
+            mmap_mode = None
 
-        x_flow = np.load(paths["x"], mmap_mode=mmap)
-        y_flow = np.load(paths["y"], mmap_mode=mmap)
-        timestamps = np.load(paths["timestamp"], mmap_mode=mmap)
+        x_flow = np.load(paths["x"], mmap_mode=mmap_mode)
+        y_flow = np.load(paths["y"], mmap_mode=mmap_mode)
+        timestamps = np.load(paths["timestamp"], mmap_mode=mmap_mode)
 
         if load_mode == "cached":
             x_flow = np.asarray(x_flow, dtype=np.float32)
@@ -440,292 +197,4 @@ def load_mvsec_gt_flow(
 
         return x_flow, y_flow, timestamps
     except OSError:
-        # cache might be on a read only fs or gone, fall back to raw npz
         return _load_gt_flow_from_npz_file(source_path)
-
-
-# Lazy HDF5 reader (process safe, pickle safe)
-
-
-class _LazyH5Dataset:
-    """Process local lazy reader for a single HDF5 dataset.
-
-    Reopens the file handle after fork() or unpickle since HDF5
-    handles are not safe across process boundaries.
-    """
-
-    def __init__(self, file_path: str, dataset_key: str, dtype: type) -> None:
-        self._file_path = file_path
-        self._dataset_key = dataset_key
-        self._dtype = dtype
-        self._file: Optional[h5py.File] = None
-        self._dataset: Optional[h5py.Dataset] = None
-        self._pid: Optional[int] = None
-        self._closed = False
-
-    def __getstate__(self) -> dict:
-        # HDF5 handles cant cross process boundaries, strip them
-        state = self.__dict__.copy()
-        state["_file"] = None
-        state["_dataset"] = None
-        state["_pid"] = None
-        return state
-
-    @property
-    def has_open_handle(self) -> bool:
-        return self._file is not None
-
-    def _ensure_open(self) -> Optional[h5py.Dataset]:
-        if self._closed:
-            return None
-
-        pid = os.getpid()
-        if self._dataset is not None and self._pid == pid:
-            return self._dataset
-
-        self._drop_handles()
-
-        self._file = open_hdf5(self._file_path)
-        self._dataset = self._file[self._dataset_key]
-        self._pid = pid
-        return self._dataset
-
-    def _drop_handles(self) -> None:
-        if self._file is not None:
-            self._file.close()
-        self._file = None
-        self._dataset = None
-        self._pid = None
-
-    def read(self, index: int) -> "Optional[npt.NDArray[np.generic]]":
-        ds = self._ensure_open()
-        if ds is None:
-            return None
-        arr: npt.NDArray[np.generic] = np.asarray(ds[index], dtype=self._dtype)
-        arr.flags.writeable = False
-        return arr
-
-    def close(self) -> None:
-        self._drop_handles()
-        self._closed = True
-
-
-# Event backends
-
-
-class _EventBackend(abc.ABC):
-    """Interface for loading slices of an MVSEC event stream."""
-
-    @property
-    @abc.abstractmethod
-    def num_events(self) -> int: ...
-
-    @abc.abstractmethod
-    def load_events(self, start_index: int, end_index: int) -> RawEvents: ...
-
-    @abc.abstractmethod
-    def time_to_index(self, t: float) -> int:
-        """Index of the last event strictly before *t*."""
-
-    @abc.abstractmethod
-    def index_to_time(self, index: int) -> float: ...
-
-    @abc.abstractmethod
-    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]: ...
-
-    @abc.abstractmethod
-    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]: ...
-
-    @abc.abstractmethod
-    def close(self) -> None: ...
-
-
-class _CachedEventBackend(_EventBackend):
-    """All events resident in RAM as typed frozen columns."""
-
-    def __init__(
-        self,
-        x_values: npt.NDArray[np.int16],
-        y_values: npt.NDArray[np.int16],
-        timestamp_values: npt.NDArray[np.float64],
-        polarity_values: npt.NDArray[np.bool_],
-    ) -> None:
-        self._x = x_values
-        self._y = y_values
-        self._timestamp = timestamp_values
-        self._polarity = polarity_values
-
-    @classmethod
-    def from_event_dataset(cls, event_dataset: h5py.Dataset) -> "_CachedEventBackend":
-        """Read directly from HDF5 into frozen in memory columns."""
-        n = int(event_dataset.shape[0])
-        x = np.empty(n, dtype=np.int16)
-        y = np.empty(n, dtype=np.int16)
-        t = np.empty(n, dtype=np.float64)
-        p = np.empty(n, dtype=np.bool_)
-
-        _copy_event_rows_into_columns(event_dataset, x, y, t, p)
-        _freeze_event_columns(x, y, t, p)
-        return cls(x, y, t, p)
-
-    @classmethod
-    def from_sidecar(
-        cls,
-        source_path: str,
-        dataset_key: str,
-        sequence: str,
-        camera: str,
-        cache_root: str,
-    ) -> "_CachedEventBackend":
-        """Load from persistent sidecar cache."""
-        x, y, t, p = load_mvsec_cached_events(
-            source_path,
-            dataset_key,
-            sequence,
-            camera,
-            cache_root,
-        )
-        return cls(x, y, t, p)
-
-    @property
-    def num_events(self) -> int:
-        return len(self._timestamp)
-
-    def load_events(self, start_index: int, end_index: int) -> RawEvents:
-        s = slice(start_index, end_index)
-        return RawEvents(
-            x=self._x[s].copy(),
-            y=self._y[s].copy(),
-            timestamp=self._timestamp[s].copy(),
-            polarity=self._polarity[s].copy(),
-        )
-
-    def time_to_index(self, t: float) -> int:
-        return int(self._timestamp.searchsorted(t, side="left") - 1)
-
-    def index_to_time(self, index: int) -> float:
-        return float(self._timestamp[index])
-
-    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
-        ts = np.asarray(timestamps, dtype=np.float64)
-        return np.asarray(self._timestamp.searchsorted(ts, side="left") - 1, dtype=np.int64)
-
-    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
-        idx = np.asarray(indices, dtype=np.int64)
-        return np.asarray(self._timestamp[idx], dtype=np.float64)
-
-    def close(self) -> None:
-        pass
-
-
-class _LazyEventBackend(_EventBackend):
-    """Sidecar backed event access via read only memmaps.
-
-    Builds the sidecar once, then mmaps into it. The OS pages data
-    in and out so this works for sequences too large to fit in RAM.
-    Memmaps are process local so we reopen after fork/unpickle.
-    """
-
-    def __init__(
-        self,
-        source_path: str,
-        dataset_key: str,
-        sequence: str,
-        camera: str,
-        cache_root: str,
-    ) -> None:
-        self._source_path = os.path.abspath(source_path)
-        self._dataset_key = dataset_key
-        self._sequence = sequence
-        self._camera = camera
-        self._cache_root = cache_root
-
-        self._cache_dir, self._cache_paths, meta = _prepare_event_cache(
-            source_path,
-            dataset_key,
-            sequence,
-            camera,
-            cache_root,
-        )
-
-        self._num_events = int(meta["num_events"])
-        self._x: Optional[npt.NDArray[np.int16]] = None
-        self._y: Optional[npt.NDArray[np.int16]] = None
-        self._timestamp: Optional[npt.NDArray[np.float64]] = None
-        self._polarity: Optional[npt.NDArray[np.bool_]] = None
-        self._pid: Optional[int] = None
-
-    def __getstate__(self) -> dict:
-        # memmaps are process local, drop and reopen lazily after unpickle
-        state = self.__dict__.copy()
-        state["_x"] = None
-        state["_y"] = None
-        state["_timestamp"] = None
-        state["_polarity"] = None
-        state["_pid"] = None
-        return state
-
-    @property
-    def num_events(self) -> int:
-        return self._num_events
-
-    def _ensure_open(self) -> None:
-        pid = os.getpid()
-        if (
-            self._pid == pid
-            and self._x is not None
-            and self._y is not None
-            and self._timestamp is not None
-            and self._polarity is not None
-        ):
-            return
-
-        self._x = np.load(self._cache_paths["x"], mmap_mode="r")
-        self._y = np.load(self._cache_paths["y"], mmap_mode="r")
-        self._timestamp = np.load(self._cache_paths["timestamp"], mmap_mode="r")
-        self._polarity = np.load(self._cache_paths["polarity"], mmap_mode="r")
-        self._pid = pid
-
-    def load_events(self, start_index: int, end_index: int) -> RawEvents:
-        self._ensure_open()
-        assert self._x is not None
-        assert self._y is not None
-        assert self._timestamp is not None
-        assert self._polarity is not None
-
-        s = slice(start_index, end_index)
-        return RawEvents(
-            x=self._x[s].copy(),
-            y=self._y[s].copy(),
-            timestamp=self._timestamp[s].copy(),
-            polarity=self._polarity[s].copy(),
-        )
-
-    def time_to_index(self, t: float) -> int:
-        self._ensure_open()
-        assert self._timestamp is not None
-        return int(self._timestamp.searchsorted(t, side="left") - 1)
-
-    def index_to_time(self, index: int) -> float:
-        self._ensure_open()
-        assert self._timestamp is not None
-        return float(self._timestamp[index])
-
-    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
-        self._ensure_open()
-        assert self._timestamp is not None
-        ts = np.asarray(timestamps, dtype=np.float64)
-        return np.asarray(self._timestamp.searchsorted(ts, side="left") - 1, dtype=np.int64)
-
-    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
-        self._ensure_open()
-        assert self._timestamp is not None
-        idx = np.asarray(indices, dtype=np.int64)
-        return np.asarray(self._timestamp[idx], dtype=np.float64)
-
-    def close(self) -> None:
-        self._x = None
-        self._y = None
-        self._timestamp = None
-        self._polarity = None
-        self._pid = None

--- a/src/evlib/dataloaders/_mvsec_storage.py
+++ b/src/evlib/dataloaders/_mvsec_storage.py
@@ -1,5 +1,7 @@
 """Private storage backends for MVSEC loader internals."""
 
+from __future__ import annotations
+
 import abc
 import hashlib
 import json

--- a/src/evlib/dataloaders/_mvsec_storage.py
+++ b/src/evlib/dataloaders/_mvsec_storage.py
@@ -1,0 +1,729 @@
+"""Private storage backends for MVSEC loader internals."""
+
+import abc
+import hashlib
+import json
+import os
+import shutil
+import uuid
+from typing import Literal
+from typing import Optional
+from typing import TypedDict
+from typing import Union
+from typing import cast
+
+import h5py
+import numpy as np
+import numpy.typing as npt
+from numpy.lib.format import open_memmap
+
+from evlib.codec.fileformat.hdf5 import open_hdf5
+from evlib.types import RawEvents
+
+
+ResidentLoadMode = Literal["cached", "lazy"]
+
+# bump these when the on disk sidecar format changes
+_EVENT_CACHE_SCHEMA_VERSION = 1
+_EVENT_BUILD_BLOCK_ROWS = 1_000_000  # keep peak memory bounded during HDF5 reads
+_GT_FLOW_CACHE_SCHEMA_VERSION = 1
+
+
+class _EventCacheMetadata(TypedDict):
+    schema_version: int
+    source_path: str
+    dataset_key: str
+    source_size: int
+    source_mtime_ns: int
+    num_events: int
+
+
+class _GTFlowCacheMetadata(TypedDict):
+    schema_version: int
+    source_path: str
+    source_size: int
+    source_mtime_ns: int
+
+
+def normalize_resident_load_mode(name: str, value: str) -> ResidentLoadMode:
+    if value not in ("cached", "lazy"):
+        raise ValueError(f"{name} must be 'cached' or 'lazy', got {value!r}")
+    return cast(ResidentLoadMode, value)
+
+
+def resolve_mvsec_cache_dir(cache_dir: Optional[str]) -> str:
+    """Resolve per user MVSEC cache directory.
+
+    Falls back to ``$XDG_CACHE_HOME/evlib/mvsec`` or ``~/.cache/evlib/mvsec``.
+    """
+    if cache_dir is not None:
+        return os.path.abspath(os.path.expanduser(cache_dir))
+
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg is not None:
+        base = os.path.expanduser(xdg)
+    else:
+        base = os.path.join(os.path.expanduser("~"), ".cache")
+
+    return os.path.abspath(os.path.join(base, "evlib", "mvsec"))
+
+
+# Cache signatures and paths
+
+
+def _make_cache_signature(
+    source_path: str,
+    dataset_key: str,
+    source_size: int,
+    source_mtime_ns: int,
+) -> str:
+    """Content addressed hash so a changed source file gets a fresh sidecar."""
+    parts = [
+        os.path.abspath(source_path),
+        dataset_key,
+        str(source_size),
+        str(source_mtime_ns),
+        str(_EVENT_CACHE_SCHEMA_VERSION),
+    ]
+    return hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()
+
+
+def _make_event_cache_dir(
+    cache_root: str,
+    source_path: str,
+    dataset_key: str,
+    sequence: str,
+    camera: str,
+) -> str:
+    stat = os.stat(source_path)
+    sig = _make_cache_signature(
+        source_path,
+        dataset_key,
+        int(stat.st_size),
+        int(stat.st_mtime_ns),
+    )
+    name = f"{sequence}_{camera}_{sig[:16]}"
+    return os.path.join(cache_root, "event_sidecars", name)
+
+
+def _make_event_cache_paths(cache_dir: str) -> dict:
+    return {
+        "x": os.path.join(cache_dir, "events_x.npy"),
+        "y": os.path.join(cache_dir, "events_y.npy"),
+        "timestamp": os.path.join(cache_dir, "events_t.npy"),
+        "polarity": os.path.join(cache_dir, "events_p.npy"),
+        "metadata": os.path.join(cache_dir, "metadata.json"),
+    }
+
+
+def _make_gt_flow_cache_dir(
+    cache_root: str,
+    source_path: str,
+    sequence: str,
+) -> str:
+    stat = os.stat(source_path)
+    parts = [
+        os.path.abspath(source_path),
+        str(int(stat.st_size)),
+        str(int(stat.st_mtime_ns)),
+        str(_GT_FLOW_CACHE_SCHEMA_VERSION),
+    ]
+    sig = hashlib.sha1("|".join(parts).encode("utf-8")).hexdigest()
+    return os.path.join(cache_root, "gt_flow_sidecars", f"{sequence}_{sig[:16]}")
+
+
+def _make_gt_flow_cache_paths(cache_dir: str) -> dict[str, str]:
+    return {
+        "x": os.path.join(cache_dir, "x_flow.npy"),
+        "y": os.path.join(cache_dir, "y_flow.npy"),
+        "timestamp": os.path.join(cache_dir, "timestamps.npy"),
+        "metadata": os.path.join(cache_dir, "metadata.json"),
+    }
+
+
+def _write_json(path: str, data: Union[_EventCacheMetadata, _GTFlowCacheMetadata]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+
+
+# Cache metadata and staleness checks
+
+
+def _load_event_cache_metadata(metadata_path: str) -> Optional[_EventCacheMetadata]:
+    if not os.path.isfile(metadata_path):
+        return None
+    with open(metadata_path, "r", encoding="utf-8") as f:
+        return cast(_EventCacheMetadata, json.load(f))
+
+
+def _load_gt_flow_cache_metadata(metadata_path: str) -> Optional[_GTFlowCacheMetadata]:
+    if not os.path.isfile(metadata_path):
+        return None
+    with open(metadata_path, "r", encoding="utf-8") as f:
+        return cast(_GTFlowCacheMetadata, json.load(f))
+
+
+def _event_cache_is_complete(
+    cache_dir: str,
+    source_path: str,
+    dataset_key: str,
+) -> Optional[_EventCacheMetadata]:
+    """Return metadata if the sidecar is complete and still matches the source file."""
+    paths = _make_event_cache_paths(cache_dir)
+    meta = _load_event_cache_metadata(paths["metadata"])
+    if meta is None:
+        return None
+
+    if not all(os.path.isfile(paths[k]) for k in ("x", "y", "timestamp", "polarity")):
+        return None
+
+    # staleness - size + mtime, not content hash (good enough, and fast)
+    stat = os.stat(source_path)
+    if (
+        meta["schema_version"] != _EVENT_CACHE_SCHEMA_VERSION
+        or meta["source_path"] != os.path.abspath(source_path)
+        or meta["dataset_key"] != dataset_key
+        or meta["source_size"] != int(stat.st_size)
+        or meta["source_mtime_ns"] != int(stat.st_mtime_ns)
+    ):
+        return None
+
+    return meta
+
+
+def _gt_flow_cache_is_complete(
+    cache_dir: str,
+    source_path: str,
+) -> Optional[_GTFlowCacheMetadata]:
+    paths = _make_gt_flow_cache_paths(cache_dir)
+    meta = _load_gt_flow_cache_metadata(paths["metadata"])
+    if meta is None:
+        return None
+
+    if not all(os.path.isfile(paths[k]) for k in ("x", "y", "timestamp")):
+        return None
+
+    stat = os.stat(source_path)
+    if (
+        meta["schema_version"] != _GT_FLOW_CACHE_SCHEMA_VERSION
+        or meta["source_path"] != os.path.abspath(source_path)
+        or meta["source_size"] != int(stat.st_size)
+        or meta["source_mtime_ns"] != int(stat.st_mtime_ns)
+    ):
+        return None
+
+    return meta
+
+
+# Building sidecars
+
+# Both builders use the same pattern - write into a uuid temp dir then
+# atomic os.replace into the real path, readers never see half written files
+
+# TODO: no file lock, concurrent builds of the same sidecar will race but
+# the last os.replace wins and the result is still valid.
+
+
+def _copy_event_rows_into_columns(
+    event_dataset: h5py.Dataset,
+    x_values: npt.NDArray[np.int16],
+    y_values: npt.NDArray[np.int16],
+    timestamp_values: npt.NDArray[np.float64],
+    polarity_values: npt.NDArray[np.bool_],
+) -> None:
+    """Blockwise HDF5 read into pre allocated typed columns.
+
+    MVSEC stores events as (N, 4) float64 rows. Streaming in fixed blocks
+    avoids loading the full table into memory for large sequences.
+    """
+    n = int(event_dataset.shape[0])
+    buf = np.empty((_EVENT_BUILD_BLOCK_ROWS, 4), dtype=np.float64)
+    start = 0
+
+    while start < n:
+        end = min(start + _EVENT_BUILD_BLOCK_ROWS, n)
+        block = buf[: end - start]
+        event_dataset.read_direct(block, source_sel=np.s_[start:end, :])
+
+        x_values[start:end] = block[:, 0]
+        y_values[start:end] = block[:, 1]
+        timestamp_values[start:end] = block[:, 2]
+        # MVSEC pol is +1/-1 float, convert to bool
+        np.greater(block[:, 3], 0.0, out=polarity_values[start:end])
+
+        start = end
+
+
+def _freeze_event_columns(
+    x_values: npt.NDArray[np.int16],
+    y_values: npt.NDArray[np.int16],
+    timestamp_values: npt.NDArray[np.float64],
+    polarity_values: npt.NDArray[np.bool_],
+) -> None:
+    for arr in (x_values, y_values, timestamp_values, polarity_values):
+        arr.flags.writeable = False
+
+
+def _build_event_cache(
+    source_path: str,
+    dataset_key: str,
+    cache_dir: str,
+) -> _EventCacheMetadata:
+    """Build typed npy sidecar from the HDF5 events table."""
+    parent = os.path.dirname(cache_dir)
+    os.makedirs(parent, exist_ok=True)
+
+    tmp = os.path.join(parent, f".tmp_{uuid.uuid4().hex}")
+    if os.path.isdir(tmp):
+        shutil.rmtree(tmp)
+    os.makedirs(tmp, exist_ok=True)
+
+    paths = _make_event_cache_paths(tmp)
+
+    try:
+        with open_hdf5(source_path) as h5:
+            ds = h5[dataset_key]
+            n = int(ds.shape[0])
+
+            x = open_memmap(paths["x"], mode="w+", dtype=np.int16, shape=(n,))
+            y = open_memmap(paths["y"], mode="w+", dtype=np.int16, shape=(n,))
+            t = open_memmap(paths["timestamp"], mode="w+", dtype=np.float64, shape=(n,))
+            p = open_memmap(paths["polarity"], mode="w+", dtype=np.bool_, shape=(n,))
+
+            _copy_event_rows_into_columns(ds, x, y, t, p)
+
+            x.flush()
+            y.flush()
+            t.flush()
+            p.flush()
+
+        stat = os.stat(source_path)
+        meta: _EventCacheMetadata = {
+            "schema_version": _EVENT_CACHE_SCHEMA_VERSION,
+            "source_path": os.path.abspath(source_path),
+            "dataset_key": dataset_key,
+            "source_size": int(stat.st_size),
+            "source_mtime_ns": int(stat.st_mtime_ns),
+            "num_events": n,
+        }
+        _write_json(paths["metadata"], meta)
+
+        if os.path.isdir(cache_dir):
+            shutil.rmtree(cache_dir)
+        os.replace(tmp, cache_dir)
+        return meta
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+
+def _build_gt_flow_cache(
+    source_path: str,
+    cache_dir: str,
+) -> _GTFlowCacheMetadata:
+    parent = os.path.dirname(cache_dir)
+    os.makedirs(parent, exist_ok=True)
+
+    tmp = os.path.join(parent, f".tmp_{uuid.uuid4().hex}")
+    if os.path.isdir(tmp):
+        shutil.rmtree(tmp)
+    os.makedirs(tmp, exist_ok=True)
+
+    paths = _make_gt_flow_cache_paths(tmp)
+
+    try:
+        with np.load(source_path) as npz:
+            x_flow = np.asarray(npz["x_flow_dist"], dtype=np.float32)
+            y_flow = np.asarray(npz["y_flow_dist"], dtype=np.float32)
+            timestamps = np.asarray(npz["timestamps"], dtype=np.float64)
+
+        np.save(paths["x"], x_flow)
+        np.save(paths["y"], y_flow)
+        np.save(paths["timestamp"], timestamps)
+
+        stat = os.stat(source_path)
+        meta: _GTFlowCacheMetadata = {
+            "schema_version": _GT_FLOW_CACHE_SCHEMA_VERSION,
+            "source_path": os.path.abspath(source_path),
+            "source_size": int(stat.st_size),
+            "source_mtime_ns": int(stat.st_mtime_ns),
+        }
+        _write_json(paths["metadata"], meta)
+
+        if os.path.isdir(cache_dir):
+            shutil.rmtree(cache_dir)
+        os.replace(tmp, cache_dir)
+        return meta
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+
+# Loading from sidecars
+
+
+def _prepare_event_cache(
+    source_path: str,
+    dataset_key: str,
+    sequence: str,
+    camera: str,
+    cache_root: str,
+) -> tuple[str, dict[str, str], _EventCacheMetadata]:
+    """Ensure an event sidecar exists and return (cache_dir, paths, metadata)."""
+    src = os.path.abspath(source_path)
+    cache_dir = _make_event_cache_dir(cache_root, src, dataset_key, sequence, camera)
+    paths = _make_event_cache_paths(cache_dir)
+    meta = _event_cache_is_complete(cache_dir, src, dataset_key)
+    if meta is None:
+        meta = _build_event_cache(src, dataset_key, cache_dir)
+    return cache_dir, paths, meta
+
+
+def load_mvsec_cached_events(
+    source_path: str,
+    dataset_key: str,
+    sequence: str,
+    camera: str,
+    cache_root: str,
+) -> tuple[
+    npt.NDArray[np.int16],
+    npt.NDArray[np.int16],
+    npt.NDArray[np.float64],
+    npt.NDArray[np.bool_],
+]:
+    """Load event columns from a persistent sidecar into RAM (frozen)."""
+    _, paths, _ = _prepare_event_cache(source_path, dataset_key, sequence, camera, cache_root)
+    x = np.load(paths["x"])
+    y = np.load(paths["y"])
+    t = np.load(paths["timestamp"])
+    p = np.load(paths["polarity"])
+    _freeze_event_columns(x, y, t, p)
+    return x, y, t, p
+
+
+def _load_gt_flow_from_npz_file(
+    source_path: str,
+) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float64]]:
+    with np.load(source_path) as npz:
+        x = np.asarray(npz["x_flow_dist"], dtype=np.float32)
+        y = np.asarray(npz["y_flow_dist"], dtype=np.float32)
+        ts = np.asarray(npz["timestamps"], dtype=np.float64)
+    return x, y, ts
+
+
+def load_mvsec_gt_flow(
+    source_path: str,
+    sequence: str,
+    cache_root: str,
+    load_mode: ResidentLoadMode,
+) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float64]]:
+    """Load GT flow arrays, building a decompressed sidecar cache if needed."""
+    try:
+        cache_dir = _make_gt_flow_cache_dir(cache_root, source_path, sequence)
+        meta = _gt_flow_cache_is_complete(cache_dir, source_path)
+        if meta is None:
+            meta = _build_gt_flow_cache(source_path, cache_dir)
+
+        paths = _make_gt_flow_cache_paths(cache_dir)
+        mmap: Optional[Literal["r"]] = "r" if load_mode == "lazy" else None
+
+        x_flow = np.load(paths["x"], mmap_mode=mmap)
+        y_flow = np.load(paths["y"], mmap_mode=mmap)
+        timestamps = np.load(paths["timestamp"], mmap_mode=mmap)
+
+        if load_mode == "cached":
+            x_flow = np.asarray(x_flow, dtype=np.float32)
+            y_flow = np.asarray(y_flow, dtype=np.float32)
+            timestamps = np.asarray(timestamps, dtype=np.float64)
+
+        return x_flow, y_flow, timestamps
+    except OSError:
+        # cache might be on a read only fs or gone, fall back to raw npz
+        return _load_gt_flow_from_npz_file(source_path)
+
+
+# Lazy HDF5 reader (process safe, pickle safe)
+
+
+class _LazyH5Dataset:
+    """Process local lazy reader for a single HDF5 dataset.
+
+    Reopens the file handle after fork() or unpickle since HDF5
+    handles are not safe across process boundaries.
+    """
+
+    def __init__(self, file_path: str, dataset_key: str, dtype: type) -> None:
+        self._file_path = file_path
+        self._dataset_key = dataset_key
+        self._dtype = dtype
+        self._file: Optional[h5py.File] = None
+        self._dataset: Optional[h5py.Dataset] = None
+        self._pid: Optional[int] = None
+        self._closed = False
+
+    def __getstate__(self) -> dict:
+        # HDF5 handles cant cross process boundaries, strip them
+        state = self.__dict__.copy()
+        state["_file"] = None
+        state["_dataset"] = None
+        state["_pid"] = None
+        return state
+
+    @property
+    def has_open_handle(self) -> bool:
+        return self._file is not None
+
+    def _ensure_open(self) -> Optional[h5py.Dataset]:
+        if self._closed:
+            return None
+
+        pid = os.getpid()
+        if self._dataset is not None and self._pid == pid:
+            return self._dataset
+
+        self._drop_handles()
+
+        self._file = open_hdf5(self._file_path)
+        self._dataset = self._file[self._dataset_key]
+        self._pid = pid
+        return self._dataset
+
+    def _drop_handles(self) -> None:
+        if self._file is not None:
+            self._file.close()
+        self._file = None
+        self._dataset = None
+        self._pid = None
+
+    def read(self, index: int) -> "Optional[npt.NDArray[np.generic]]":
+        ds = self._ensure_open()
+        if ds is None:
+            return None
+        arr: npt.NDArray[np.generic] = np.asarray(ds[index], dtype=self._dtype)
+        arr.flags.writeable = False
+        return arr
+
+    def close(self) -> None:
+        self._drop_handles()
+        self._closed = True
+
+
+# Event backends
+
+
+class _EventBackend(abc.ABC):
+    """Interface for loading slices of an MVSEC event stream."""
+
+    @property
+    @abc.abstractmethod
+    def num_events(self) -> int: ...
+
+    @abc.abstractmethod
+    def load_events(self, start_index: int, end_index: int) -> RawEvents: ...
+
+    @abc.abstractmethod
+    def time_to_index(self, t: float) -> int:
+        """Index of the last event strictly before *t*."""
+
+    @abc.abstractmethod
+    def index_to_time(self, index: int) -> float: ...
+
+    @abc.abstractmethod
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]: ...
+
+    @abc.abstractmethod
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]: ...
+
+    @abc.abstractmethod
+    def close(self) -> None: ...
+
+
+class _CachedEventBackend(_EventBackend):
+    """All events resident in RAM as typed frozen columns."""
+
+    def __init__(
+        self,
+        x_values: npt.NDArray[np.int16],
+        y_values: npt.NDArray[np.int16],
+        timestamp_values: npt.NDArray[np.float64],
+        polarity_values: npt.NDArray[np.bool_],
+    ) -> None:
+        self._x = x_values
+        self._y = y_values
+        self._timestamp = timestamp_values
+        self._polarity = polarity_values
+
+    @classmethod
+    def from_event_dataset(cls, event_dataset: h5py.Dataset) -> "_CachedEventBackend":
+        """Read directly from HDF5 into frozen in memory columns."""
+        n = int(event_dataset.shape[0])
+        x = np.empty(n, dtype=np.int16)
+        y = np.empty(n, dtype=np.int16)
+        t = np.empty(n, dtype=np.float64)
+        p = np.empty(n, dtype=np.bool_)
+
+        _copy_event_rows_into_columns(event_dataset, x, y, t, p)
+        _freeze_event_columns(x, y, t, p)
+        return cls(x, y, t, p)
+
+    @classmethod
+    def from_sidecar(
+        cls,
+        source_path: str,
+        dataset_key: str,
+        sequence: str,
+        camera: str,
+        cache_root: str,
+    ) -> "_CachedEventBackend":
+        """Load from persistent sidecar cache."""
+        x, y, t, p = load_mvsec_cached_events(
+            source_path,
+            dataset_key,
+            sequence,
+            camera,
+            cache_root,
+        )
+        return cls(x, y, t, p)
+
+    @property
+    def num_events(self) -> int:
+        return len(self._timestamp)
+
+    def load_events(self, start_index: int, end_index: int) -> RawEvents:
+        s = slice(start_index, end_index)
+        return RawEvents(
+            x=self._x[s].copy(),
+            y=self._y[s].copy(),
+            timestamp=self._timestamp[s].copy(),
+            polarity=self._polarity[s].copy(),
+        )
+
+    def time_to_index(self, t: float) -> int:
+        return int(self._timestamp.searchsorted(t, side="left") - 1)
+
+    def index_to_time(self, index: int) -> float:
+        return float(self._timestamp[index])
+
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        ts = np.asarray(timestamps, dtype=np.float64)
+        return np.asarray(self._timestamp.searchsorted(ts, side="left") - 1, dtype=np.int64)
+
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        idx = np.asarray(indices, dtype=np.int64)
+        return np.asarray(self._timestamp[idx], dtype=np.float64)
+
+    def close(self) -> None:
+        pass
+
+
+class _LazyEventBackend(_EventBackend):
+    """Sidecar backed event access via read only memmaps.
+
+    Builds the sidecar once, then mmaps into it. The OS pages data
+    in and out so this works for sequences too large to fit in RAM.
+    Memmaps are process local so we reopen after fork/unpickle.
+    """
+
+    def __init__(
+        self,
+        source_path: str,
+        dataset_key: str,
+        sequence: str,
+        camera: str,
+        cache_root: str,
+    ) -> None:
+        self._source_path = os.path.abspath(source_path)
+        self._dataset_key = dataset_key
+        self._sequence = sequence
+        self._camera = camera
+        self._cache_root = cache_root
+
+        self._cache_dir, self._cache_paths, meta = _prepare_event_cache(
+            source_path,
+            dataset_key,
+            sequence,
+            camera,
+            cache_root,
+        )
+
+        self._num_events = int(meta["num_events"])
+        self._x: Optional[npt.NDArray[np.int16]] = None
+        self._y: Optional[npt.NDArray[np.int16]] = None
+        self._timestamp: Optional[npt.NDArray[np.float64]] = None
+        self._polarity: Optional[npt.NDArray[np.bool_]] = None
+        self._pid: Optional[int] = None
+
+    def __getstate__(self) -> dict:
+        # memmaps are process local, drop and reopen lazily after unpickle
+        state = self.__dict__.copy()
+        state["_x"] = None
+        state["_y"] = None
+        state["_timestamp"] = None
+        state["_polarity"] = None
+        state["_pid"] = None
+        return state
+
+    @property
+    def num_events(self) -> int:
+        return self._num_events
+
+    def _ensure_open(self) -> None:
+        pid = os.getpid()
+        if (
+            self._pid == pid
+            and self._x is not None
+            and self._y is not None
+            and self._timestamp is not None
+            and self._polarity is not None
+        ):
+            return
+
+        self._x = np.load(self._cache_paths["x"], mmap_mode="r")
+        self._y = np.load(self._cache_paths["y"], mmap_mode="r")
+        self._timestamp = np.load(self._cache_paths["timestamp"], mmap_mode="r")
+        self._polarity = np.load(self._cache_paths["polarity"], mmap_mode="r")
+        self._pid = pid
+
+    def load_events(self, start_index: int, end_index: int) -> RawEvents:
+        self._ensure_open()
+        assert self._x is not None
+        assert self._y is not None
+        assert self._timestamp is not None
+        assert self._polarity is not None
+
+        s = slice(start_index, end_index)
+        return RawEvents(
+            x=self._x[s].copy(),
+            y=self._y[s].copy(),
+            timestamp=self._timestamp[s].copy(),
+            polarity=self._polarity[s].copy(),
+        )
+
+    def time_to_index(self, t: float) -> int:
+        self._ensure_open()
+        assert self._timestamp is not None
+        return int(self._timestamp.searchsorted(t, side="left") - 1)
+
+    def index_to_time(self, index: int) -> float:
+        self._ensure_open()
+        assert self._timestamp is not None
+        return float(self._timestamp[index])
+
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        self._ensure_open()
+        assert self._timestamp is not None
+        ts = np.asarray(timestamps, dtype=np.float64)
+        return np.asarray(self._timestamp.searchsorted(ts, side="left") - 1, dtype=np.int64)
+
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        self._ensure_open()
+        assert self._timestamp is not None
+        idx = np.asarray(indices, dtype=np.int64)
+        return np.asarray(self._timestamp[idx], dtype=np.float64)
+
+    def close(self) -> None:
+        self._x = None
+        self._y = None
+        self._timestamp = None
+        self._polarity = None
+        self._pid = None

--- a/src/evlib/dataloaders/_mvsec_types.py
+++ b/src/evlib/dataloaders/_mvsec_types.py
@@ -1,0 +1,21 @@
+"""MVSEC specific container types."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass(frozen=True)
+class MVSECOdometryData:
+    """MVSEC odometry samples loaded from ``*_odom.npz``."""
+
+    timestamps: npt.NDArray[np.float64]
+    linear_velocity: npt.NDArray[np.float64]
+    position: npt.NDArray[np.float64]
+    quaternion: npt.NDArray[np.float64]
+    angular_velocity: npt.NDArray[np.float64]
+
+    def __len__(self) -> int:
+        """Return the num of odometry samples."""
+        return len(self.timestamps)

--- a/src/evlib/dataloaders/_mvsec_types.py
+++ b/src/evlib/dataloaders/_mvsec_types.py
@@ -1,4 +1,4 @@
-"""MVSEC specific container types."""
+"""MVSEC specific lightweight container types."""
 
 from dataclasses import dataclass
 
@@ -8,7 +8,7 @@ import numpy.typing as npt
 
 @dataclass(frozen=True)
 class MVSECOdometryData:
-    """MVSEC odometry samples loaded from ``*_odom.npz``."""
+    """Container for MVSEC odometry samples loaded from ``*_odom.npz``."""
 
     timestamps: npt.NDArray[np.float64]
     linear_velocity: npt.NDArray[np.float64]
@@ -17,5 +17,5 @@ class MVSECOdometryData:
     angular_velocity: npt.NDArray[np.float64]
 
     def __len__(self) -> int:
-        """Return the num of odometry samples."""
+        """Return the number of odometry samples."""
         return len(self.timestamps)

--- a/src/evlib/dataloaders/_storage_common.py
+++ b/src/evlib/dataloaders/_storage_common.py
@@ -1,0 +1,94 @@
+"""Common storage helpers shared by dataloader implementations."""
+
+import os
+from typing import Literal
+from typing import Optional
+from typing import cast
+
+import h5py
+import numpy as np
+import numpy.typing as npt
+
+from evlib.codec.fileformat.hdf5 import open_hdf5
+
+
+ResidentLoadMode = Literal["cached", "lazy"]
+
+
+def normalize_resident_load_mode(name: str, value: str) -> ResidentLoadMode:
+    """Validate and normalize a resident loading mode string."""
+    if value not in ("cached", "lazy"):
+        raise ValueError(f"{name} must be 'cached' or 'lazy', got {value!r}")
+
+    mode = cast(ResidentLoadMode, value)
+    return mode
+
+
+class _LazyH5Dataset:
+    """Process local lazy reader for a single HDF5 dataset.
+
+    Reopens the file handle after fork() or unpickle since HDF5
+    handles are not safe across process boundaries.
+    """
+
+    def __init__(self, file_path: str, dataset_key: str, dtype: type) -> None:
+        self._file_path = file_path
+        self._dataset_key = dataset_key
+        self._dtype = dtype
+        self._file: Optional[h5py.File] = None
+        self._dataset: Optional[h5py.Dataset] = None
+        self._pid: Optional[int] = None
+        self._closed = False
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state["_file"] = None
+        state["_dataset"] = None
+        state["_pid"] = None
+        return state
+
+    @property
+    def has_open_handle(self) -> bool:
+        return self._file is not None
+
+    def _ensure_open(self) -> Optional[h5py.Dataset]:
+        if self._closed:
+            return None
+
+        pid = os.getpid()
+        same_process = self._pid == pid
+        has_dataset = self._dataset is not None
+        if same_process and has_dataset:
+            return self._dataset
+
+        self._drop_handles()
+
+        file_handle = open_hdf5(self._file_path)
+        dataset = file_handle[self._dataset_key]
+
+        self._file = file_handle
+        self._dataset = dataset
+        self._pid = pid
+        return dataset
+
+    def _drop_handles(self) -> None:
+        file_handle = self._file
+        if file_handle is not None:
+            file_handle.close()
+
+        self._file = None
+        self._dataset = None
+        self._pid = None
+
+    def read(self, index: int) -> "Optional[npt.NDArray[np.generic]]":
+        dataset = self._ensure_open()
+        if dataset is None:
+            return None
+
+        array: npt.NDArray[np.generic] = np.asarray(dataset[index], dtype=self._dtype)
+        array.flags.writeable = False
+        return array
+
+    def close(self) -> None:
+        self._drop_handles()
+        self._closed = True

--- a/src/evlib/dataloaders/_storage_common.py
+++ b/src/evlib/dataloaders/_storage_common.py
@@ -1,9 +1,12 @@
 """Common storage helpers shared by dataloader implementations."""
 
+from __future__ import annotations
+
 import os
+from enum import Enum
 from typing import Literal
 from typing import Optional
-from typing import cast
+from typing import Union
 
 import h5py
 import numpy as np
@@ -12,16 +15,65 @@ import numpy.typing as npt
 from evlib.codec.fileformat.hdf5 import open_hdf5
 
 
-ResidentLoadMode = Literal["cached", "lazy"]
+LoadMode = Union[bool, Literal["lazy", "cached"], "LoadingType"]
+ResidentLoadMode = Union[Literal["lazy", "cached"], "LoadingType"]
 
 
-def normalize_resident_load_mode(name: str, value: str) -> ResidentLoadMode:
-    """Validate and normalize a resident loading mode string."""
-    if value not in ("cached", "lazy"):
+class LoadingType(str, Enum):
+    """internal loading state for dataset modalities."""
+
+    OFF = "off"
+    LAZY = "lazy"
+    CACHED = "cached"
+
+    @classmethod
+    def from_value(
+        cls,
+        value: LoadMode,
+        *,
+        name: str = "loading type",
+    ) -> "LoadingType":
+        if isinstance(value, cls):
+            return value
+
+        if value is False:
+            return cls.OFF
+
+        if value is True or value == "lazy":
+            return cls.LAZY
+
+        if value == "cached":
+            return cls.CACHED
+
+        raise ValueError(f"Invalid {name}: {value!r}. Expected False, True, 'lazy', or 'cached'.")
+
+    @classmethod
+    def from_resident_value(
+        cls,
+        value: ResidentLoadMode,
+        *,
+        name: str,
+    ) -> "LoadingType":
+        if isinstance(value, cls):
+            if value is cls.OFF:
+                raise ValueError(f"{name} must be 'cached' or 'lazy', got {value!r}")
+            return value
+
+        if value == "lazy":
+            return cls.LAZY
+
+        if value == "cached":
+            return cls.CACHED
+
         raise ValueError(f"{name} must be 'cached' or 'lazy', got {value!r}")
 
-    mode = cast(ResidentLoadMode, value)
-    return mode
+    @property
+    def should_load(self) -> bool:
+        return self is not self.OFF
+
+    @property
+    def should_cache(self) -> bool:
+        return self is self.CACHED
 
 
 class _LazyH5Dataset:

--- a/src/evlib/dataloaders/utils.py
+++ b/src/evlib/dataloaders/utils.py
@@ -1,0 +1,137 @@
+from functools import lru_cache
+from typing import Any
+from typing import Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+_cv2: Any = None
+
+try:
+    import cv2 as _cv2
+except ImportError:
+    _cv2 = None
+
+cv2: Any = _cv2
+
+
+def find_nearest_index(timestamps: npt.NDArray[np.float64], t: float) -> int:
+    """Return the index of the timestamp nearest to ``t``."""
+    index = int(np.searchsorted(timestamps, t, side="left"))
+
+    if index >= len(timestamps):
+        return len(timestamps) - 1
+
+    if index == 0:
+        return 0
+
+    left_distance = abs(t - timestamps[index - 1])
+    right_distance = abs(t - timestamps[index])
+    return index - 1 if left_distance <= right_distance else index
+
+
+@lru_cache(maxsize=8)
+def get_flow_coordinate_grid(
+    height: int,
+    width: int,
+) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
+    """Return cached base coordinate grids for dense flow propagation."""
+    x_coords, y_coords = np.meshgrid(
+        np.arange(width, dtype=np.float32),
+        np.arange(height, dtype=np.float32),
+        indexing="xy",
+    )
+    x_coords.flags.writeable = False
+    y_coords.flags.writeable = False
+    return x_coords, y_coords
+
+
+def sample_flow_nearest_numpy(
+    x_flow: npt.NDArray[np.float32],
+    y_flow: npt.NDArray[np.float32],
+    x_coords: npt.NDArray[np.float32],
+    y_coords: npt.NDArray[np.float32],
+) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
+    """Sample dense flow at floating coordinates with NumPy nearest neighbor."""
+    x_indices = np.rint(x_coords).astype(np.int32)
+    y_indices = np.rint(y_coords).astype(np.int32)
+
+    height, width = x_flow.shape
+    valid = (x_indices >= 0) & (x_indices < width) & (y_indices >= 0) & (y_indices < height)
+
+    sampled_x = np.zeros_like(x_flow, dtype=np.float32)
+    sampled_y = np.zeros_like(y_flow, dtype=np.float32)
+
+    if np.any(valid):
+        sampled_x[valid] = x_flow[y_indices[valid], x_indices[valid]]
+        sampled_y[valid] = y_flow[y_indices[valid], x_indices[valid]]
+
+    return sampled_x, sampled_y, valid
+
+
+def sample_flow_nearest(
+    x_flow: npt.NDArray[np.float32],
+    y_flow: npt.NDArray[np.float32],
+    x_coords: npt.NDArray[np.float32],
+    y_coords: npt.NDArray[np.float32],
+) -> Tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
+    """Sample dense flow at floating coordinates with nearest-neighbor."""
+    x_indices = np.rint(x_coords).astype(np.int32)
+    y_indices = np.rint(y_coords).astype(np.int32)
+
+    height, width = x_flow.shape
+    valid = (x_indices >= 0) & (x_indices < width) & (y_indices >= 0) & (y_indices < height)
+
+    if cv2 is None:
+        return sample_flow_nearest_numpy(x_flow, y_flow, x_coords, y_coords)
+
+    sampled_x = np.asarray(
+        cv2.remap(
+            x_flow,
+            x_coords,
+            y_coords,
+            interpolation=cv2.INTER_NEAREST,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=0,
+        ),
+        dtype=np.float32,
+    )
+    sampled_y = np.asarray(
+        cv2.remap(
+            y_flow,
+            x_coords,
+            y_coords,
+            interpolation=cv2.INTER_NEAREST,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=0,
+        ),
+        dtype=np.float32,
+    )
+    return sampled_x, sampled_y, valid
+
+
+def propagate_flow_step(
+    x_flow: npt.NDArray[np.float32],
+    y_flow: npt.NDArray[np.float32],
+    x_coords: npt.NDArray[np.float32],
+    y_coords: npt.NDArray[np.float32],
+    x_mask: npt.NDArray[np.bool_],
+    y_mask: npt.NDArray[np.bool_],
+    scale: float,
+) -> None:
+    """Propagate pixel coordinates through one GT flow field in place."""
+    sampled_x, sampled_y, valid = sample_flow_nearest(
+        x_flow,
+        y_flow,
+        x_coords,
+        y_coords,
+    )
+
+    x_mask &= valid
+    y_mask &= valid
+    x_mask[sampled_x == 0.0] = False
+    y_mask[sampled_y == 0.0] = False
+
+    x_coords += sampled_x * scale
+    y_coords += sampled_y * scale

--- a/tests/dataloaders/test_mvsec.py
+++ b/tests/dataloaders/test_mvsec.py
@@ -1,0 +1,1183 @@
+"""Tests for MVSECDataLoader and DataLoaderBase.
+
+Reuses the same synthetic MVSEC format files as test_mvsec.py.
+"""
+
+import pickle
+
+import h5py
+import numpy as np
+from pathlib import Path
+
+import pytest
+
+from evlib.dataloaders import MVSECOdometryData
+from evlib.dataloaders._base import DataLoaderBase
+from evlib.dataloaders._mvsec import MVSECDataLoader
+from evlib.dataloaders._mvsec import _find_nearest_index
+from evlib.dataloaders._mvsec import _resolve_load_mode
+from evlib.types import RawEvents
+
+
+HEIGHT, WIDTH = 260, 346
+N_EVENTS = 500
+N_FRAMES = 20
+N_GT_FRAMES = 10
+N_IMU = 100
+N_DEPTH_FRAMES = 10
+N_ODOM_FRAMES = 12
+N_POSE_FRAMES = 50
+N_VELODYNE_SCANS = 8
+N_VELODYNE_POINTS = 200  # small for fast tests
+SEQ = "indoor_flying1"
+CATEGORY = "indoor_flying"
+T_START = 1504645177.0
+T_END = 1504645247.0
+
+
+# Synthetic data helpers
+
+
+def _make_hdf5(
+    path: Path, n_events: int = N_EVENTS, n_frames: int = N_FRAMES, camera: str = "left"
+) -> None:
+    """Create a minimal MVSEC format HDF5 file matching real layout."""
+    rng = np.random.RandomState(42)
+    x = rng.randint(0, WIDTH, n_events).astype(np.float64)
+    y = rng.randint(0, HEIGHT, n_events).astype(np.float64)
+    t = np.sort(rng.uniform(T_START, T_END, n_events))
+    p = rng.choice([-1.0, 1.0], n_events)
+    events = np.stack([x, y, t, p], axis=1)
+
+    with h5py.File(path, "w") as f:
+        grp = f.create_group(f"davis/{camera}")
+        grp.create_dataset("events", data=events)
+        grp.create_dataset(
+            "image_raw", data=rng.randint(0, 256, (n_frames, HEIGHT, WIDTH), dtype=np.uint8)
+        )
+        frame_ts = np.linspace(T_START, T_END, n_frames)
+        grp.create_dataset("image_raw_ts", data=frame_ts)
+        grp.create_dataset(
+            "image_raw_event_inds",
+            data=np.linspace(0, n_events - 1, n_frames, dtype=np.int64),
+        )
+
+
+def _add_imu_to_hdf5(path: Path, camera: str = "left") -> None:
+    """Add IMU datasets to an existing data HDF5."""
+    rng = np.random.RandomState(3)
+    with h5py.File(path, "a") as f:
+        grp = f[f"davis/{camera}"]
+        imu_data = rng.normal(0, 1, (N_IMU, 6))
+        grp.create_dataset("imu", data=imu_data)
+        imu_ts = np.linspace(T_START, T_END, N_IMU)
+        grp.create_dataset("imu_ts", data=imu_ts)
+
+
+def _add_velodyne_to_hdf5(path: Path) -> None:
+    """Add velodyne datasets to an existing data HDF5."""
+    rng = np.random.RandomState(5)
+    with h5py.File(path, "a") as f:
+        vel_grp = f.create_group("velodyne")
+        scans = rng.uniform(-10, 10, (N_VELODYNE_SCANS, N_VELODYNE_POINTS, 4)).astype(np.float32)
+        vel_grp.create_dataset("scans", data=scans)
+        vel_ts = np.linspace(T_START, T_END, N_VELODYNE_SCANS)
+        vel_grp.create_dataset("scans_ts", data=vel_ts)
+
+
+def _make_gt_flow_npz(path: Path, n_frames: int = N_GT_FRAMES) -> None:
+    rng = np.random.RandomState(0)
+    x_flow_dist = rng.uniform(-5, 5, (n_frames, HEIGHT, WIDTH))
+    y_flow_dist = rng.uniform(-5, 5, (n_frames, HEIGHT, WIDTH))
+    timestamps = np.linspace(T_START, T_END, n_frames)
+    np.savez(path, x_flow_dist=x_flow_dist, y_flow_dist=y_flow_dist, timestamps=timestamps)
+
+
+def _make_constant_gt_flow_npz(
+    path: Path, x_value: float = 4.0, y_value: float = -2.0, n_frames: int = 4
+) -> None:
+    x_flow_dist = np.full((n_frames, HEIGHT, WIDTH), x_value, dtype=np.float32)
+    y_flow_dist = np.full((n_frames, HEIGHT, WIDTH), y_value, dtype=np.float32)
+    timestamps = np.linspace(T_START, T_END, n_frames)
+    np.savez(path, x_flow_dist=x_flow_dist, y_flow_dist=y_flow_dist, timestamps=timestamps)
+
+
+def _make_odom_npz(path: Path, n_frames: int = N_ODOM_FRAMES) -> None:
+    """Create synthetic odometry NPZ."""
+    rng = np.random.RandomState(11)
+    np.savez(
+        path,
+        timestamps=np.linspace(T_START, T_END, n_frames),
+        lin_vel=rng.normal(0, 1, (n_frames, 3)),
+        pos=rng.normal(0, 1, (n_frames, 3)),
+        quat=rng.normal(0, 1, (n_frames, 4)),
+        ang_vel=rng.normal(0, 1, (n_frames, 3)),
+    )
+
+
+def _make_gt_hdf5(path: Path, camera: str = "left") -> None:
+    """Create synthetic gt.hdf5 with depth, blended, flow, odometry, poses."""
+    rng = np.random.RandomState(7)
+    with h5py.File(path, "w") as f:
+        grp = f.create_group(f"davis/{camera}")
+
+        # Depth (raw)
+        depth_raw = rng.uniform(0.5, 50.0, (N_DEPTH_FRAMES, HEIGHT, WIDTH)).astype(np.float32)
+        grp.create_dataset("depth_image_raw", data=depth_raw)
+        grp.create_dataset("depth_image_raw_ts", data=np.linspace(T_START, T_END, N_DEPTH_FRAMES))
+
+        # Depth (rectified)
+        depth_rect = rng.uniform(0.5, 50.0, (N_DEPTH_FRAMES, HEIGHT, WIDTH)).astype(np.float32)
+        grp.create_dataset("depth_image_rect", data=depth_rect)
+        grp.create_dataset("depth_image_rect_ts", data=np.linspace(T_START, T_END, N_DEPTH_FRAMES))
+
+        # Blended images
+        blended = rng.randint(0, 256, (N_DEPTH_FRAMES, HEIGHT, WIDTH, 3), dtype=np.uint8)
+        grp.create_dataset("blended_image_rect", data=blended)
+        grp.create_dataset(
+            "blended_image_rect_ts", data=np.linspace(T_START, T_END, N_DEPTH_FRAMES)
+        )
+
+        # Flow in HDF5
+        flow = rng.uniform(-5, 5, (N_DEPTH_FRAMES, 2, HEIGHT, WIDTH))
+        grp.create_dataset("flow_dist", data=flow)
+        grp.create_dataset("flow_dist_ts", data=np.linspace(T_START, T_END, N_DEPTH_FRAMES))
+
+        # GT odometry (LOAM)
+        odom = np.tile(np.eye(4), (N_ODOM_FRAMES, 1, 1))
+        grp.create_dataset("odometry", data=odom)
+        grp.create_dataset("odometry_ts", data=np.linspace(T_START, T_END, N_ODOM_FRAMES))
+
+        # GT pose (Cartographer)
+        pose = np.tile(np.eye(4), (N_POSE_FRAMES, 1, 1))
+        grp.create_dataset("pose", data=pose)
+        grp.create_dataset("pose_ts", data=np.linspace(T_START, T_END, N_POSE_FRAMES))
+
+
+def _assert_raw_events_equal(left: RawEvents, right: RawEvents) -> None:
+    """Assert that two RawEvents batches contain identical data."""
+    np.testing.assert_array_equal(left.x, right.x)
+    np.testing.assert_array_equal(left.y, right.y)
+    np.testing.assert_array_equal(left.timestamp, right.timestamp)
+    np.testing.assert_array_equal(left.polarity, right.polarity)
+
+
+# Fixtures
+
+
+@pytest.fixture()
+def mvsec_dir(tmp_path: Path) -> Path:
+    """Synthetic MVSEC directory with GT flow (no calibration)."""
+    _make_hdf5(tmp_path / f"{SEQ}_data.hdf5")
+    _make_gt_flow_npz(tmp_path / f"{SEQ}_gt_flow_dist.npz")
+    return tmp_path
+
+
+@pytest.fixture()
+def mvsec_full_dir(tmp_path: Path) -> Path:
+    """Synthetic MVSEC directory with all modalities."""
+    data_path = tmp_path / f"{SEQ}_data.hdf5"
+    _make_hdf5(data_path)
+    _add_imu_to_hdf5(data_path)
+    _add_velodyne_to_hdf5(data_path)
+    _make_gt_flow_npz(tmp_path / f"{SEQ}_gt_flow_dist.npz")
+    _make_odom_npz(tmp_path / f"{SEQ}_odom.npz")
+    _make_gt_hdf5(tmp_path / f"{SEQ}_gt.hdf5")
+    return tmp_path
+
+
+# Test helpers
+
+
+class TestResolveLoadMode:
+    def test_false(self) -> None:
+        should_load, should_cache = _resolve_load_mode(False)
+        assert should_load is False
+        assert should_cache is False
+
+    def test_true(self) -> None:
+        should_load, should_cache = _resolve_load_mode(True)
+        assert should_load is True
+        assert should_cache is False
+
+    def test_lazy_string(self) -> None:
+        should_load, should_cache = _resolve_load_mode("lazy")
+        assert should_load is True
+        assert should_cache is False
+
+    def test_cached_string(self) -> None:
+        should_load, should_cache = _resolve_load_mode("cached")
+        assert should_load is True
+        assert should_cache is True
+
+    def test_invalid(self) -> None:
+        with pytest.raises(ValueError):
+            _resolve_load_mode("invalid")  # type: ignore[arg-type]
+
+
+class TestResidentLoadModes:
+    def test_invalid_event_mode_raises(self, mvsec_dir: Path) -> None:
+        with pytest.raises(ValueError, match="event_load_mode"):
+            MVSECDataLoader(
+                str(mvsec_dir),
+                SEQ,
+                load_calibration=False,
+                event_load_mode="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_image_mode_raises(self, mvsec_dir: Path) -> None:
+        with pytest.raises(ValueError, match="image_load_mode"):
+            MVSECDataLoader(
+                str(mvsec_dir),
+                SEQ,
+                load_calibration=False,
+                image_load_mode="invalid",  # type: ignore[arg-type]
+            )
+
+
+class TestFindNearestIndex:
+    def test_exact_match(self) -> None:
+        ts = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        assert _find_nearest_index(ts, 3.0) == 2
+
+    def test_between_values(self) -> None:
+        ts = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        assert _find_nearest_index(ts, 2.3) == 1
+        assert _find_nearest_index(ts, 2.7) == 2
+
+    def test_before_start(self) -> None:
+        ts = np.array([1.0, 2.0, 3.0])
+        assert _find_nearest_index(ts, 0.0) == 0
+
+    def test_after_end(self) -> None:
+        ts = np.array([1.0, 2.0, 3.0])
+        assert _find_nearest_index(ts, 99.0) == 2
+
+
+# Existing dataloader tests
+
+
+class TestDataLoaderBase:
+    def test_cannot_instantiate(self) -> None:
+        """DataLoaderBase is abstract and cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            DataLoaderBase()  # type: ignore[abstract]
+
+
+class TestMVSECDataLoader:
+    def test_isinstance_dataloader_base(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            assert isinstance(loader, DataLoaderBase)
+
+    def test_load_events(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            events = loader.load_events(0, 100)
+            assert isinstance(events, RawEvents)
+            assert len(events) == 100
+            assert events.x.dtype == np.int16
+            assert events.y.dtype == np.int16
+            assert events.timestamp.dtype == np.float64
+            assert events.polarity.dtype == np.bool_
+
+    def test_num_events(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            assert loader.num_events == N_EVENTS
+
+    def test_time_to_index(self, mvsec_dir: Path) -> None:
+        """time_to_index returns the last event strictly before t."""
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            t_mid = (T_START + T_END) / 2
+            idx = loader.time_to_index(t_mid)
+            assert -1 <= idx < N_EVENTS
+            if idx >= 0:
+                assert loader.index_to_time(idx) < t_mid
+            if idx + 1 < N_EVENTS:
+                assert loader.index_to_time(idx + 1) >= t_mid
+
+    def test_index_to_time(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            t0 = loader.index_to_time(0)
+            t_last = loader.index_to_time(N_EVENTS - 1)
+            assert T_START <= t0 <= t_last <= T_END
+
+    def test_times_to_indices_matches_scalar(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            query_times = np.array([T_START, (T_START + T_END) / 2, T_END], dtype=np.float64)
+            bulk_indices = loader.times_to_indices(query_times)
+            scalar_indices = np.array([loader.time_to_index(float(t)) for t in query_times])
+            np.testing.assert_array_equal(bulk_indices, scalar_indices)
+
+    def test_indices_to_times_matches_scalar(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            query_indices = np.array([0, N_EVENTS // 2, N_EVENTS - 1], dtype=np.int64)
+            bulk_timestamps = loader.indices_to_times(query_indices)
+            scalar_timestamps = np.array([loader.index_to_time(int(i)) for i in query_indices])
+            np.testing.assert_array_equal(bulk_timestamps, scalar_timestamps)
+
+    def test_time_to_index_with_duplicate_timestamps(self, tmp_path: Path) -> None:
+        duplicate_timestamps = np.array([1.0, 1.0, 2.0, 2.0], dtype=np.float64)
+        x = np.array([0, 1, 2, 3], dtype=np.float64)
+        y = np.array([0, 0, 1, 1], dtype=np.float64)
+        p = np.array([1.0, -1.0, 1.0, -1.0], dtype=np.float64)
+        events = np.stack([x, y, duplicate_timestamps, p], axis=1)
+
+        with h5py.File(tmp_path / f"{SEQ}_data.hdf5", "w") as f:
+            grp = f.create_group("davis/left")
+            grp.create_dataset("events", data=events)
+            grp.create_dataset("image_raw_ts", data=np.array([1.0, 2.0], dtype=np.float64))
+
+        cache_dir = tmp_path / ".cache"
+        with MVSECDataLoader(
+            str(tmp_path),
+            SEQ,
+            load_gt_flow=False,
+            load_calibration=False,
+            event_load_mode="lazy",
+            cache_dir=str(cache_dir),
+        ) as loader:
+            assert loader.time_to_index(1.0) == -1
+            assert loader.time_to_index(2.0) == 1
+
+    def test_get_events_by_time(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            t_mid = (T_START + T_END) / 2
+            events = loader.get_events_by_time(T_START, t_mid)
+            assert isinstance(events, RawEvents)
+            assert len(events) > 0
+            assert np.all(events.timestamp >= T_START)
+            assert np.all(events.timestamp < t_mid)
+
+    def test_iter_events_by_count(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            chunks = list(loader.iter_events(num_events=100))
+            assert len(chunks) > 0
+            total = sum(len(c) for c in chunks)
+            assert total == N_EVENTS
+            for c in chunks[:-1]:
+                assert len(c) == 100
+
+    def test_iter_events_by_time(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            window = (T_END - T_START) / 5
+            chunks = list(loader.iter_events(time_window=window))
+            assert len(chunks) > 0
+            total = sum(len(c) for c in chunks)
+            assert total == N_EVENTS
+
+    def test_load_optical_flow(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_gt_flow=True,
+            load_calibration=False,
+        ) as loader:
+            assert loader.has_gt_flow
+            gt_ts = loader.gt_time_list()
+            flow = loader.load_optical_flow(gt_ts[0], gt_ts[2])
+            assert flow.shape == (HEIGHT, WIDTH, 2)
+
+    def test_load_optical_flow_within_single_gt_interval_scales_constant_flow(
+        self, tmp_path: Path
+    ) -> None:
+        _make_hdf5(tmp_path / f"{SEQ}_data.hdf5")
+        _make_constant_gt_flow_npz(tmp_path / f"{SEQ}_gt_flow_dist.npz")
+
+        with MVSECDataLoader(
+            str(tmp_path), SEQ, load_gt_flow=True, load_calibration=False
+        ) as loader:
+            gt_ts = loader.gt_time_list()
+            gt_interval_duration = gt_ts[1] - gt_ts[0]
+            t_start = gt_ts[0] + 0.1 * gt_interval_duration
+            t_end = gt_ts[0] + 0.6 * gt_interval_duration
+            requested_duration = t_end - t_start
+            scale_factor = requested_duration / gt_interval_duration
+
+            flow = loader.load_optical_flow(float(t_start), float(t_end))
+
+            np.testing.assert_allclose(flow[..., 0], 4.0 * scale_factor)
+            np.testing.assert_allclose(flow[..., 1], -2.0 * scale_factor)
+
+    def test_load_optical_flow_across_multiple_gt_intervals_accumulates_constant_flow(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _make_hdf5(tmp_path / f"{SEQ}_data.hdf5")
+        _make_constant_gt_flow_npz(tmp_path / f"{SEQ}_gt_flow_dist.npz")
+
+        with MVSECDataLoader(
+            str(tmp_path), SEQ, load_gt_flow=True, load_calibration=False
+        ) as loader:
+            gt_ts = loader.gt_time_list()
+            flow = loader.load_optical_flow(float(gt_ts[0]), float(gt_ts[2]))
+
+            valid_region = flow[4:, :-8]
+            np.testing.assert_allclose(valid_region[..., 0], 8.0)
+            np.testing.assert_allclose(valid_region[..., 1], -4.0)
+
+    def test_load_frame_sample_returns_flow_for_short_frame_interval(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_gt_flow=True,
+            load_calibration=False,
+        ) as loader:
+            sample = loader.load_frame_sample(1)
+            assert sample["flow"] is not None
+
+    def test_num_frames(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            assert loader.num_frames == N_FRAMES
+
+    def test_load_image(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            img = loader.load_image(0)
+            assert img is not None
+            assert img.shape == (HEIGHT, WIDTH)
+            assert img.dtype == np.uint8
+
+    def test_lazy_event_mode_matches_cached(self, mvsec_dir: Path) -> None:
+        cache_dir = mvsec_dir / ".cache"
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as cached_loader:
+            with MVSECDataLoader(
+                str(mvsec_dir),
+                SEQ,
+                load_calibration=False,
+                event_load_mode="lazy",
+                cache_dir=str(cache_dir),
+            ) as lazy_loader:
+                cached_events = cached_loader.load_events(10, 120)
+                lazy_events = lazy_loader.load_events(10, 120)
+                _assert_raw_events_equal(cached_events, lazy_events)
+
+                t_mid = (T_START + T_END) / 2
+                assert lazy_loader.time_to_index(t_mid) == cached_loader.time_to_index(t_mid)
+                assert lazy_loader.index_to_time(42) == cached_loader.index_to_time(42)
+
+                cached_time_window = cached_loader.get_events_by_time(T_START, t_mid)
+                lazy_time_window = lazy_loader.get_events_by_time(T_START, t_mid)
+                _assert_raw_events_equal(cached_time_window, lazy_time_window)
+
+    def test_lazy_image_mode_loads_readonly_frame(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            image_load_mode="lazy",
+        ) as loader:
+            assert loader.has_images
+            assert loader.images is None
+
+            img = loader.load_image(0)
+            assert img is not None
+            assert img.shape == (HEIGHT, WIDTH)
+            assert img.dtype == np.uint8
+            assert img.flags.writeable is False
+
+    def test_lazy_event_mode_survives_close(self, mvsec_dir: Path) -> None:
+        cache_dir = mvsec_dir / ".cache"
+        loader = MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            event_load_mode="lazy",
+            cache_dir=str(cache_dir),
+        )
+        before_close = loader.load_events(5, 25)
+        loader.close()
+        after_close = loader.load_events(5, 25)
+        _assert_raw_events_equal(before_close, after_close)
+
+    def test_lazy_event_mode_builds_and_reuses_sidecar(self, mvsec_dir: Path) -> None:
+        cache_dir = mvsec_dir / ".cache"
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            event_load_mode="lazy",
+            cache_dir=str(cache_dir),
+        ) as first_loader:
+            first_loader.load_events(0, 10)
+
+        metadata_files = sorted(cache_dir.rglob("metadata.json"))
+        assert len(metadata_files) == 1
+
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            event_load_mode="lazy",
+            cache_dir=str(cache_dir),
+        ) as second_loader:
+            second_events = second_loader.load_events(0, 10)
+            assert len(second_events) == 10
+
+    def test_cached_event_mode_with_explicit_cache_dir_builds_and_reuses_sidecar(
+        self, mvsec_dir: Path
+    ) -> None:
+        cache_dir = mvsec_dir / ".cache"
+
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as direct_loader:
+            direct_events = direct_loader.load_events(0, 20)
+
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            event_load_mode="cached",
+            cache_dir=str(cache_dir),
+        ) as first_loader:
+            first_events = first_loader.load_events(0, 20)
+            _assert_raw_events_equal(first_events, direct_events)
+
+        metadata_files = sorted(cache_dir.rglob("metadata.json"))
+        assert len(metadata_files) == 1
+
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            event_load_mode="cached",
+            cache_dir=str(cache_dir),
+        ) as second_loader:
+            second_events = second_loader.load_events(0, 20)
+            _assert_raw_events_equal(second_events, direct_events)
+
+    def test_lazy_image_mode_releases_on_close(self, mvsec_dir: Path) -> None:
+        loader = MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            image_load_mode="lazy",
+        )
+        before_close = loader.load_image(0)
+        assert before_close is not None
+        loader.close()
+        after_close = loader.load_image(0)
+        assert after_close is None
+
+    def test_lazy_image_loader_is_pickle_safe(self, mvsec_dir: Path) -> None:
+        loader = MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            image_load_mode="lazy",
+        )
+        first_image = loader.load_image(0)
+        assert first_image is not None
+
+        restored_loader = pickle.loads(pickle.dumps(loader))
+        restored_image = restored_loader.load_image(0)
+        assert restored_image is not None
+        np.testing.assert_array_equal(restored_image, first_image)
+        assert restored_image.flags.writeable is False
+
+    def test_iter_events_invalid_num_events(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            with pytest.raises(ValueError):
+                list(loader.iter_events(num_events=0))
+            with pytest.raises(ValueError):
+                list(loader.iter_events(num_events=-1))
+
+    def test_iter_events_invalid_time_window(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            with pytest.raises(ValueError):
+                list(loader.iter_events(time_window=0.0))
+            with pytest.raises(ValueError):
+                list(loader.iter_events(time_window=-1.0))
+
+    def test_iter_events_empty_sequence(self, tmp_path: Path) -> None:
+        """iter_events on an empty sequence yields nothing instead of crashing."""
+        with h5py.File(tmp_path / f"{SEQ}_data.hdf5", "w") as f:
+            grp = f.create_group("davis/left")
+            grp.create_dataset("events", data=np.empty((0, 4), dtype=np.float64))
+            grp.create_dataset("image_raw_ts", data=np.array([], dtype=np.float64))
+        with MVSECDataLoader(
+            str(tmp_path), SEQ, load_gt_flow=False, load_calibration=False
+        ) as loader:
+            assert list(loader.iter_events(num_events=100)) == []
+            assert list(loader.iter_events(time_window=1.0)) == []
+
+    def test_context_manager(self, mvsec_dir: Path) -> None:
+        loader = MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False)
+        with loader:
+            _ = loader.load_events(0, 10)
+        # Data stays usable because arrays are cached during __init__.
+        assert len(loader.load_events(0, 10)) == 10
+
+
+# IMU tests
+
+
+class TestMVSECDataLoaderIMU:
+    def test_has_imu(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir), SEQ, load_calibration=False, load_gt_flow=False, load_imu=True
+        ) as loader:
+            assert loader.has_imu
+
+    def test_imu_not_loaded_by_default(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir), SEQ, load_calibration=False, load_gt_flow=False
+        ) as loader:
+            assert not loader.has_imu
+
+    def test_imu_timestamps(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir), SEQ, load_calibration=False, load_gt_flow=False, load_imu=True
+        ) as loader:
+            ts = loader.imu_timestamps
+            assert ts is not None
+            assert len(ts) == N_IMU
+            assert ts.dtype == np.float64
+
+    def test_imu_data_shape(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir), SEQ, load_calibration=False, load_gt_flow=False, load_imu=True
+        ) as loader:
+            imu = loader.imu_data
+            assert imu is not None
+            assert imu.shape == (N_IMU, 6)
+            assert imu.dtype == np.float64
+
+    def test_load_imu_windowed(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir), SEQ, load_calibration=False, load_gt_flow=False, load_imu=True
+        ) as loader:
+            t_mid = (T_START + T_END) / 2
+            result = loader.load_imu(T_START, t_mid)
+            assert result is not None
+            readings, timestamps = result
+            assert readings.ndim == 2
+            assert readings.shape[1] == 6
+            assert len(readings) == len(timestamps)
+            assert np.all(timestamps >= T_START)
+            assert np.all(timestamps < t_mid)
+
+    def test_load_imu_returns_none_when_not_loaded(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            result = loader.load_imu(T_START, T_END)
+            assert result is None
+
+
+# Odometry NPZ tests
+
+
+class TestMVSECDataLoaderOdometryNPZ:
+    def test_has_odometry_npz(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_odometry_npz=True,
+        ) as loader:
+            assert loader.has_odometry_npz
+
+    def test_odometry_npz_not_loaded_by_default(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir), SEQ, load_calibration=False, load_gt_flow=False
+        ) as loader:
+            assert not loader.has_odometry_npz
+
+    def test_odometry_npz_type(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_odometry_npz=True,
+        ) as loader:
+            odom = loader.odometry_npz
+            assert isinstance(odom, MVSECOdometryData)
+
+    def test_odometry_npz_shapes(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_odometry_npz=True,
+        ) as loader:
+            odom = loader.odometry_npz
+            assert odom is not None
+            assert odom.timestamps.shape == (N_ODOM_FRAMES,)
+            assert odom.linear_velocity.shape == (N_ODOM_FRAMES, 3)
+            assert odom.position.shape == (N_ODOM_FRAMES, 3)
+            assert odom.quaternion.shape == (N_ODOM_FRAMES, 4)
+            assert odom.angular_velocity.shape == (N_ODOM_FRAMES, 3)
+
+    def test_odometry_npz_len(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_odometry_npz=True,
+        ) as loader:
+            odom = loader.odometry_npz
+            assert odom is not None
+            assert len(odom) == N_ODOM_FRAMES
+
+    def test_odometry_npz_dtypes(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_odometry_npz=True,
+        ) as loader:
+            odom = loader.odometry_npz
+            assert odom is not None
+            assert odom.timestamps.dtype == np.float64
+            assert odom.linear_velocity.dtype == np.float64
+            assert odom.position.dtype == np.float64
+            assert odom.quaternion.dtype == np.float64
+            assert odom.angular_velocity.dtype == np.float64
+
+    def test_odometry_npz_read_only(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_odometry_npz=True,
+        ) as loader:
+            odom = loader.odometry_npz
+            assert odom is not None
+            assert not odom.timestamps.flags.writeable
+
+
+# GT Depth tests
+
+
+class TestMVSECDataLoaderGTDepth:
+    def test_has_gt_depth_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_raw="lazy",
+        ) as loader:
+            assert loader.has_gt_depth
+            assert loader.has_gt_depth_raw
+            assert not loader.has_gt_depth_rect
+
+    def test_has_gt_depth_cached(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_rect="cached",
+        ) as loader:
+            assert loader.has_gt_depth
+            assert not loader.has_gt_depth_raw
+            assert loader.has_gt_depth_rect
+
+    def test_load_depth_raw_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_raw="lazy",
+        ) as loader:
+            depth = loader.load_depth_raw(0)
+            assert depth is not None
+            assert depth.shape == (HEIGHT, WIDTH)
+            assert depth.dtype == np.float32
+
+    def test_load_depth_raw_cached(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_raw="cached",
+        ) as loader:
+            depth = loader.load_depth_raw(0)
+            assert depth is not None
+            assert depth.shape == (HEIGHT, WIDTH)
+            assert depth.dtype == np.float32
+            assert loader.depth_raw_images is not None
+
+    def test_load_depth_rectified_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_rect="lazy",
+        ) as loader:
+            depth = loader.load_depth_rect(0)
+            assert depth is not None
+            assert depth.shape == (HEIGHT, WIDTH)
+            assert depth.dtype == np.float32
+
+    def test_depth_timestamps(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_raw=True,
+        ) as loader:
+            ts = loader.gt_depth_raw_timestamps
+            assert ts is not None
+            assert len(ts) == N_DEPTH_FRAMES
+            assert ts.dtype == np.float64
+
+    def test_num_gt_depth_frames(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_rect=True,
+        ) as loader:
+            assert loader.num_gt_depth_frames == N_DEPTH_FRAMES
+            assert loader.num_gt_depth_rect_frames == N_DEPTH_FRAMES
+
+
+# GT Blended images tests
+
+
+class TestMVSECDataLoaderGTBlended:
+    def test_has_gt_blended_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_blended="lazy",
+        ) as loader:
+            assert loader.has_gt_blended
+
+    def test_load_blended_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_blended="lazy",
+        ) as loader:
+            img = loader.load_blended_image(0)
+            assert img is not None
+            assert img.shape == (HEIGHT, WIDTH, 3)
+            assert img.dtype == np.uint8
+
+    def test_load_blended_cached(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_blended="cached",
+        ) as loader:
+            img = loader.load_blended_image(0)
+            assert img is not None
+            assert img.shape == (HEIGHT, WIDTH, 3)
+            assert img.dtype == np.uint8
+            assert loader.blended_images is not None
+
+
+# GT Flow HDF5 tests
+
+
+class TestMVSECDataLoaderGTFlowHDF5:
+    def test_has_gt_flow_hdf5_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_flow_hdf5="lazy",
+        ) as loader:
+            assert loader.has_gt_flow_hdf5
+
+    def test_load_flow_hdf5_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_flow_hdf5="lazy",
+        ) as loader:
+            flow = loader.load_flow_hdf5(0)
+            assert flow is not None
+            assert flow.shape == (2, HEIGHT, WIDTH)
+            assert flow.dtype == np.float64
+
+    def test_load_flow_hdf5_cached(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_flow_hdf5="cached",
+        ) as loader:
+            flow = loader.load_flow_hdf5(0)
+            assert flow is not None
+            assert flow.shape == (2, HEIGHT, WIDTH)
+            assert flow.dtype == np.float64
+            assert loader.flow_hdf5_frames is not None
+
+    def test_flow_hdf5_timestamps(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_flow_hdf5=True,
+        ) as loader:
+            ts = loader.gt_flow_hdf5_timestamps
+            assert ts is not None
+            assert len(ts) == N_DEPTH_FRAMES
+
+
+# GT Poses tests
+
+
+class TestMVSECDataLoaderGTPoses:
+    def test_has_gt_odometry(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_odometry=True,
+        ) as loader:
+            assert loader.has_gt_odometry
+
+    def test_gt_odometry_shape(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_odometry=True,
+        ) as loader:
+            odom = loader.gt_odometry
+            assert odom is not None
+            assert odom.shape == (N_ODOM_FRAMES, 4, 4)
+            assert odom.dtype == np.float64
+
+    def test_has_gt_pose(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_poses=True,
+        ) as loader:
+            assert loader.has_gt_pose
+
+    def test_gt_pose_shape(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_poses=True,
+        ) as loader:
+            pose = loader.gt_pose
+            assert pose is not None
+            assert pose.shape == (N_POSE_FRAMES, 4, 4)
+            assert pose.dtype == np.float64
+
+    def test_load_nearest_pose(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_poses=True,
+        ) as loader:
+            t_mid = (T_START + T_END) / 2
+            pose = loader.load_nearest_pose(t_mid, source="pose")
+            assert pose is not None
+            assert pose.shape == (4, 4)
+            assert pose.dtype == np.float64
+
+    def test_load_nearest_odometry(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_odometry=True,
+        ) as loader:
+            t_mid = (T_START + T_END) / 2
+            pose = loader.load_nearest_pose(t_mid, source="odometry")
+            assert pose is not None
+            assert pose.shape == (4, 4)
+
+    def test_load_nearest_pose_invalid_source(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_poses=True,
+        ) as loader:
+            with pytest.raises(ValueError, match="source"):
+                loader.load_nearest_pose(T_START, source="invalid")
+
+    def test_load_nearest_pose_returns_none_when_not_loaded(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_dir), SEQ, load_calibration=False) as loader:
+            result = loader.load_nearest_pose(T_START, source="pose")
+            assert result is None
+
+
+# Velodyne tests
+
+
+class TestMVSECDataLoaderVelodyne:
+    def test_has_velodyne_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_velodyne="lazy",
+        ) as loader:
+            assert loader.has_velodyne
+
+    def test_has_velodyne_cached(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_velodyne="cached",
+        ) as loader:
+            assert loader.has_velodyne
+
+    def test_load_velodyne_scan_lazy(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_velodyne="lazy",
+        ) as loader:
+            scan = loader.load_velodyne_scan(0)
+            assert scan is not None
+            assert scan.shape == (N_VELODYNE_POINTS, 4)
+            assert scan.dtype == np.float32
+
+    def test_load_velodyne_scan_cached(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_velodyne="cached",
+        ) as loader:
+            scan = loader.load_velodyne_scan(0)
+            assert scan is not None
+            assert scan.shape == (N_VELODYNE_POINTS, 4)
+            assert scan.dtype == np.float32
+            assert loader.velodyne_scans is not None
+
+    def test_velodyne_timestamps(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_velodyne=True,
+        ) as loader:
+            ts = loader.velodyne_timestamps
+            assert ts is not None
+            assert len(ts) == N_VELODYNE_SCANS
+            assert ts.dtype == np.float64
+
+    def test_num_velodyne_scans(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_velodyne=True,
+        ) as loader:
+            assert loader.num_velodyne_scans == N_VELODYNE_SCANS
+
+
+# Close and resource management tests
+
+
+class TestMVSECDataLoaderClose:
+    def test_close_releases_lazy_velodyne(self, mvsec_full_dir: Path) -> None:
+        loader = MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_velodyne="lazy",
+        )
+        # Should work before close
+        scan = loader.load_velodyne_scan(0)
+        assert scan is not None
+        loader.close()
+        # Lazy reference should be cleared
+        result = loader.load_velodyne_scan(0)
+        assert result is None
+
+    def test_close_releases_lazy_depth(self, mvsec_full_dir: Path) -> None:
+        loader = MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_raw="lazy",
+        )
+        depth = loader.load_depth_raw(0)
+        assert depth is not None
+        loader.close()
+        result = loader.load_depth_raw(0)
+        assert result is None
+
+    def test_cached_data_survives_close(self, mvsec_full_dir: Path) -> None:
+        loader = MVSECDataLoader(
+            str(mvsec_full_dir),
+            SEQ,
+            load_calibration=False,
+            load_gt_flow=False,
+            load_gt_depth_raw="cached",
+        )
+        loader.close()
+        # Cached data should still be accessible
+        depth = loader.load_depth_raw(0)
+        assert depth is not None
+
+
+# Backward compatibility tests
+
+
+class TestMVSECDataLoaderBackwardCompat:
+    def test_old_signature(self, mvsec_dir: Path) -> None:
+        """Existing constructor signature still works identically."""
+        with MVSECDataLoader(str(mvsec_dir), SEQ, "left", True, False) as loader:
+            assert loader.has_gt_flow
+            assert loader.num_events == N_EVENTS
+
+    def test_default_profile_is_lean(self, mvsec_full_dir: Path) -> None:
+        with MVSECDataLoader(str(mvsec_full_dir), SEQ) as loader:
+            assert not loader.has_gt_flow
+            assert not loader.has_calibration
+
+    def test_new_modalities_off_by_default(self, mvsec_full_dir: Path) -> None:
+        """New modalities are not loaded unless explicitly requested."""
+        with MVSECDataLoader(
+            str(mvsec_full_dir), SEQ, load_calibration=False, load_gt_flow=False
+        ) as loader:
+            assert not loader.has_imu
+            assert not loader.has_odometry_npz
+            assert not loader.has_gt_odometry
+            assert not loader.has_gt_pose
+            assert not loader.has_gt_depth
+            assert not loader.has_gt_blended
+            assert not loader.has_gt_flow_hdf5
+            assert not loader.has_velodyne

--- a/tests/dataloaders/test_mvsec.py
+++ b/tests/dataloaders/test_mvsec.py
@@ -10,10 +10,10 @@ import h5py
 import numpy as np
 import pytest
 
+from evlib.dataloaders import LoadingType
 from evlib.dataloaders import MVSECOdometryData
 from evlib.dataloaders._base import DataLoaderBase
 from evlib.dataloaders._mvsec import MVSECDataLoader
-from evlib.dataloaders._mvsec import _resolve_load_mode
 from evlib.dataloaders.utils import find_nearest_index
 from evlib.types import RawEvents
 
@@ -188,30 +188,45 @@ def mvsec_full_dir(tmp_path: Path) -> Path:
 # Test helpers
 
 
-class TestResolveLoadMode:
+class TestLoadingType:
     def test_false(self) -> None:
-        should_load, should_cache = _resolve_load_mode(False)
-        assert should_load is False
-        assert should_cache is False
+        mode = LoadingType.from_value(False, name="load_gt_flow")
+        assert mode is LoadingType.OFF
+        assert not mode.should_load
+        assert not mode.should_cache
 
     def test_true(self) -> None:
-        should_load, should_cache = _resolve_load_mode(True)
-        assert should_load is True
-        assert should_cache is False
+        mode = LoadingType.from_value(True, name="load_gt_flow")
+        assert mode is LoadingType.LAZY
+        assert mode.should_load
+        assert not mode.should_cache
 
     def test_lazy_string(self) -> None:
-        should_load, should_cache = _resolve_load_mode("lazy")
-        assert should_load is True
-        assert should_cache is False
+        mode = LoadingType.from_value("lazy", name="load_gt_flow")
+        assert mode is LoadingType.LAZY
+        assert mode.should_load
+        assert not mode.should_cache
 
     def test_cached_string(self) -> None:
-        should_load, should_cache = _resolve_load_mode("cached")
-        assert should_load is True
-        assert should_cache is True
+        mode = LoadingType.from_value("cached", name="load_gt_flow")
+        assert mode is LoadingType.CACHED
+        assert mode.should_load
+        assert mode.should_cache
+
+    def test_resident_mode_from_enum(self, mvsec_dir: Path) -> None:
+        with MVSECDataLoader(
+            str(mvsec_dir),
+            SEQ,
+            load_calibration=False,
+            event_load_mode=LoadingType.LAZY,
+            image_load_mode=LoadingType.CACHED,
+        ) as loader:
+            assert loader.event_load_mode is LoadingType.LAZY
+            assert loader.image_load_mode is LoadingType.CACHED
 
     def test_invalid(self) -> None:
         with pytest.raises(ValueError):
-            _resolve_load_mode("invalid")  # type: ignore[arg-type]
+            LoadingType.from_value("invalid", name="load_gt_flow")  # type: ignore[arg-type]
 
 
 class TestResidentLoadModes:

--- a/tests/dataloaders/test_mvsec.py
+++ b/tests/dataloaders/test_mvsec.py
@@ -4,18 +4,17 @@ Reuses the same synthetic MVSEC format files as test_mvsec.py.
 """
 
 import pickle
+from pathlib import Path
 
 import h5py
 import numpy as np
-from pathlib import Path
-
 import pytest
 
 from evlib.dataloaders import MVSECOdometryData
 from evlib.dataloaders._base import DataLoaderBase
 from evlib.dataloaders._mvsec import MVSECDataLoader
-from evlib.dataloaders._mvsec import _find_nearest_index
 from evlib.dataloaders._mvsec import _resolve_load_mode
+from evlib.dataloaders.utils import find_nearest_index
 from evlib.types import RawEvents
 
 
@@ -238,20 +237,20 @@ class TestResidentLoadModes:
 class TestFindNearestIndex:
     def test_exact_match(self) -> None:
         ts = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        assert _find_nearest_index(ts, 3.0) == 2
+        assert find_nearest_index(ts, 3.0) == 2
 
     def test_between_values(self) -> None:
         ts = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        assert _find_nearest_index(ts, 2.3) == 1
-        assert _find_nearest_index(ts, 2.7) == 2
+        assert find_nearest_index(ts, 2.3) == 1
+        assert find_nearest_index(ts, 2.7) == 2
 
     def test_before_start(self) -> None:
         ts = np.array([1.0, 2.0, 3.0])
-        assert _find_nearest_index(ts, 0.0) == 0
+        assert find_nearest_index(ts, 0.0) == 0
 
     def test_after_end(self) -> None:
         ts = np.array([1.0, 2.0, 3.0])
-        assert _find_nearest_index(ts, 99.0) == 2
+        assert find_nearest_index(ts, 99.0) == 2
 
 
 # Existing dataloader tests

--- a/tests/dataloaders/test_mvsec_storage.py
+++ b/tests/dataloaders/test_mvsec_storage.py
@@ -1,0 +1,606 @@
+"""Tests for MVSEC storage backends and caching utilities."""
+
+import json
+import os
+from unittest import mock
+
+import h5py
+import numpy as np
+import pytest
+
+from evlib.dataloaders._mvsec_storage import ResidentLoadMode
+from evlib.dataloaders._mvsec_storage import _build_event_cache
+from evlib.dataloaders._mvsec_storage import _build_gt_flow_cache
+from evlib.dataloaders._mvsec_storage import _CachedEventBackend
+from evlib.dataloaders._mvsec_storage import _copy_event_rows_into_columns
+from evlib.dataloaders._mvsec_storage import _event_cache_is_complete
+from evlib.dataloaders._mvsec_storage import _freeze_event_columns
+from evlib.dataloaders._mvsec_storage import _gt_flow_cache_is_complete
+from evlib.dataloaders._mvsec_storage import _LazyEventBackend
+from evlib.dataloaders._mvsec_storage import _LazyH5Dataset
+from evlib.dataloaders._mvsec_storage import _load_event_cache_metadata
+from evlib.dataloaders._mvsec_storage import _load_gt_flow_cache_metadata
+from evlib.dataloaders._mvsec_storage import _make_cache_signature
+from evlib.dataloaders._mvsec_storage import _make_event_cache_dir
+from evlib.dataloaders._mvsec_storage import _make_event_cache_paths
+from evlib.dataloaders._mvsec_storage import _make_gt_flow_cache_dir
+from evlib.dataloaders._mvsec_storage import _make_gt_flow_cache_paths
+from evlib.dataloaders._mvsec_storage import _prepare_event_cache
+from evlib.dataloaders._mvsec_storage import _write_json
+from evlib.dataloaders._mvsec_storage import load_mvsec_cached_events
+from evlib.dataloaders._mvsec_storage import load_mvsec_gt_flow
+from evlib.dataloaders._mvsec_storage import normalize_resident_load_mode
+from evlib.dataloaders._mvsec_storage import resolve_mvsec_cache_dir
+from evlib.types import RawEvents
+
+
+N_EVENTS = 50
+DATASET_KEY = "davis/left/events"
+
+
+def _make_hdf5(path: str, n_events: int = N_EVENTS) -> None:
+    """minimal MVSEC like HDF5 file."""
+    with h5py.File(path, "w") as f:
+        events = np.zeros((n_events, 4), dtype=np.float64)
+        events[:, 0] = np.arange(n_events) % 10  # x
+        events[:, 1] = np.arange(n_events) % 8  # y
+        events[:, 2] = np.linspace(0.0, 1.0, n_events)  # timestamp
+        events[:, 3] = np.tile([0.0, 1.0], n_events // 2 + 1)[:n_events]  # polarity
+        f.create_dataset(DATASET_KEY, data=events)
+
+
+def _make_gt_flow_npz(path: str, n_frames: int = 5) -> None:
+    """Create a minimal GT flow NPZ file."""
+    h, w = 4, 4
+    np.savez(
+        path,
+        x_flow_dist=np.random.randn(n_frames, h, w).astype(np.float32),
+        y_flow_dist=np.random.randn(n_frames, h, w).astype(np.float32),
+        timestamps=np.linspace(0.0, 1.0, n_frames).astype(np.float64),
+    )
+
+
+class TestNormalizeResidentLoadMode:
+    def test_cached(self) -> None:
+        result = normalize_resident_load_mode("events", "cached")
+        assert result == "cached"
+
+    def test_lazy(self) -> None:
+        result = normalize_resident_load_mode("events", "lazy")
+        assert result == "lazy"
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="events must be"):
+            normalize_resident_load_mode("events", "invalid")
+
+
+class TestResolveCacheDir:
+    def test_explicit_dir(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        result = resolve_mvsec_cache_dir(str(tmp_path / "custom"))
+        assert result == str(tmp_path / "custom")
+
+    def test_default_uses_xdg(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/test_xdg")
+        result = resolve_mvsec_cache_dir(None)
+        assert "evlib" in result
+        assert "mvsec" in result
+
+    def test_default_without_xdg(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        result = resolve_mvsec_cache_dir(None)
+        assert ".cache" in result
+        assert "evlib" in result
+
+
+class TestCacheSignature:
+    def test_deterministic(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        sig1 = _make_cache_signature(hdf5_path, DATASET_KEY, 100, 999)
+        sig2 = _make_cache_signature(hdf5_path, DATASET_KEY, 100, 999)
+        assert sig1 == sig2
+
+    def test_different_inputs_differ(self) -> None:
+        sig1 = _make_cache_signature("/a", "k", 100, 999)
+        sig2 = _make_cache_signature("/b", "k", 100, 999)
+        assert sig1 != sig2
+
+
+class TestEventCachePaths:
+    def test_keys(self) -> None:
+        paths = _make_event_cache_paths("/tmp/cache")
+        assert set(paths.keys()) == {"x", "y", "timestamp", "polarity", "metadata"}
+
+    def test_event_cache_dir(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_dir = _make_event_cache_dir(
+            str(tmp_path), hdf5_path, DATASET_KEY, "indoor_flying1", "left"
+        )
+        assert "indoor_flying1_left_" in cache_dir
+
+
+class TestGTFlowCachePaths:
+    def test_keys(self) -> None:
+        paths = _make_gt_flow_cache_paths("/tmp/cache")
+        assert set(paths.keys()) == {"x", "y", "timestamp", "metadata"}
+
+    def test_gt_flow_cache_dir(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path)
+        cache_dir = _make_gt_flow_cache_dir(str(tmp_path), npz_path, "indoor_flying1")
+        assert "indoor_flying1_" in cache_dir
+
+
+class TestEventCacheMetadata:
+    def test_load_missing_returns_none(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        result = _load_event_cache_metadata(str(tmp_path / "missing.json"))
+        assert result is None
+
+    def test_round_trip(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        metadata = {
+            "schema_version": 1,
+            "source_path": "/test",
+            "dataset_key": "k",
+            "source_size": 100,
+            "source_mtime_ns": 999,
+            "num_events": 50,
+        }
+        path = str(tmp_path / "metadata.json")
+        _write_json(path, metadata)  # type: ignore[arg-type]
+        loaded = _load_event_cache_metadata(path)
+        assert loaded == metadata
+
+
+class TestGTFlowCacheMetadata:
+    def test_load_missing_returns_none(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        result = _load_gt_flow_cache_metadata(str(tmp_path / "missing.json"))
+        assert result is None
+
+
+class TestEventCacheComplete:
+    def test_returns_none_when_no_metadata(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        result = _event_cache_is_complete(str(tmp_path / "cache"), hdf5_path, DATASET_KEY)
+        assert result is None
+
+    def test_returns_none_when_files_missing(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_dir = str(tmp_path / "cache")
+        os.makedirs(cache_dir)
+        stat = os.stat(hdf5_path)
+        metadata = {
+            "schema_version": 1,
+            "source_path": os.path.abspath(hdf5_path),
+            "dataset_key": DATASET_KEY,
+            "source_size": stat.st_size,
+            "source_mtime_ns": stat.st_mtime_ns,
+            "num_events": N_EVENTS,
+        }
+        _write_json(os.path.join(cache_dir, "metadata.json"), metadata)  # type: ignore[arg-type]
+        result = _event_cache_is_complete(cache_dir, hdf5_path, DATASET_KEY)
+        assert result is None
+
+    def test_returns_none_when_stale(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_dir = str(tmp_path / "cache")
+        os.makedirs(cache_dir)
+        paths = _make_event_cache_paths(cache_dir)
+        for key in ("x", "y", "timestamp", "polarity"):
+            np.save(paths[key], np.zeros(1))
+        metadata = {
+            "schema_version": 1,
+            "source_path": os.path.abspath(hdf5_path),
+            "dataset_key": DATASET_KEY,
+            "source_size": 0,
+            "source_mtime_ns": 0,
+            "num_events": N_EVENTS,
+        }
+        _write_json(paths["metadata"], metadata)  # type: ignore[arg-type]
+        result = _event_cache_is_complete(cache_dir, hdf5_path, DATASET_KEY)
+        assert result is None
+
+
+class TestGTFlowCacheComplete:
+    def test_returns_none_when_no_metadata(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path)
+        result = _gt_flow_cache_is_complete(str(tmp_path / "cache"), npz_path)
+        assert result is None
+
+    def test_returns_none_when_files_missing(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path)
+        cache_dir = str(tmp_path / "cache")
+        os.makedirs(cache_dir)
+        stat = os.stat(npz_path)
+        metadata = {
+            "schema_version": 1,
+            "source_path": os.path.abspath(npz_path),
+            "source_size": stat.st_size,
+            "source_mtime_ns": stat.st_mtime_ns,
+        }
+        _write_json(os.path.join(cache_dir, "metadata.json"), metadata)  # type: ignore[arg-type]
+        result = _gt_flow_cache_is_complete(cache_dir, npz_path)
+        assert result is None
+
+    def test_returns_none_when_stale(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path)
+        cache_dir = str(tmp_path / "cache")
+        os.makedirs(cache_dir)
+        paths = _make_gt_flow_cache_paths(cache_dir)
+        for key in ("x", "y", "timestamp"):
+            np.save(paths[key], np.zeros(1))
+        metadata = {
+            "schema_version": 1,
+            "source_path": os.path.abspath(npz_path),
+            "source_size": 0,
+            "source_mtime_ns": 0,
+        }
+        _write_json(paths["metadata"], metadata)  # type: ignore[arg-type]
+        result = _gt_flow_cache_is_complete(cache_dir, npz_path)
+        assert result is None
+
+
+class TestBuildEventCache:
+    def test_build_and_verify(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_dir = str(tmp_path / "event_cache")
+
+        metadata = _build_event_cache(hdf5_path, DATASET_KEY, cache_dir)
+        assert metadata["num_events"] == N_EVENTS
+        assert metadata["schema_version"] == 1
+
+        paths = _make_event_cache_paths(cache_dir)
+        x = np.load(paths["x"])
+        assert len(x) == N_EVENTS
+
+        result = _event_cache_is_complete(cache_dir, hdf5_path, DATASET_KEY)
+        assert result is not None
+
+    def test_replaces_existing_cache(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_dir = str(tmp_path / "event_cache")
+
+        _build_event_cache(hdf5_path, DATASET_KEY, cache_dir)
+        metadata = _build_event_cache(hdf5_path, DATASET_KEY, cache_dir)
+        assert metadata["num_events"] == N_EVENTS
+
+
+class TestBuildGTFlowCache:
+    def test_build_and_verify(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=5)
+        cache_dir = str(tmp_path / "gt_flow_cache")
+
+        metadata = _build_gt_flow_cache(npz_path, cache_dir)
+        assert metadata["schema_version"] == 1
+
+        paths = _make_gt_flow_cache_paths(cache_dir)
+        timestamps = np.load(paths["timestamp"])
+        assert len(timestamps) == 5
+
+        result = _gt_flow_cache_is_complete(cache_dir, npz_path)
+        assert result is not None
+
+
+class TestBuildGTFlowCacheEdgeCases:
+    def test_replaces_existing_cache_dir(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=3)
+        cache_dir = str(tmp_path / "gt_cache")
+
+        _build_gt_flow_cache(npz_path, cache_dir)
+        _build_gt_flow_cache(npz_path, cache_dir)
+        paths = _make_gt_flow_cache_paths(cache_dir)
+        assert os.path.isfile(paths["metadata"])
+
+    def test_cleanup_on_error(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=3)
+        cache_dir = str(tmp_path / "gt_cache_err")
+
+        with mock.patch("evlib.dataloaders._mvsec_storage.np.save", side_effect=IOError("boom")):
+            with pytest.raises(IOError):
+                _build_gt_flow_cache(npz_path, cache_dir)
+        assert not os.path.isdir(cache_dir)
+
+
+class TestBuildGTFlowCacheTempDirExists:
+    def test_removes_pre_existing_temp_dir(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=3)
+        cache_dir = str(tmp_path / "gt_cache")
+        parent_dir = os.path.dirname(cache_dir)
+        os.makedirs(parent_dir, exist_ok=True)
+
+        fake_hex = "a" * 32
+        temp_dir = os.path.join(parent_dir, f".tmp_{fake_hex}")
+        os.makedirs(temp_dir)
+
+        fake_uuid = mock.MagicMock()
+        fake_uuid.hex = fake_hex
+        with mock.patch("evlib.dataloaders._mvsec_storage.uuid.uuid4", return_value=fake_uuid):
+            _build_gt_flow_cache(npz_path, cache_dir)
+
+        assert not os.path.isdir(temp_dir)
+        assert os.path.isdir(cache_dir)
+
+
+class TestBuildEventCacheTempDirExists:
+    def test_removes_pre_existing_temp_dir(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_dir = str(tmp_path / "event_cache")
+        parent_dir = os.path.dirname(cache_dir)
+        os.makedirs(parent_dir, exist_ok=True)
+
+        fake_hex = "b" * 32
+        temp_dir = os.path.join(parent_dir, f".tmp_{fake_hex}")
+        os.makedirs(temp_dir)
+
+        fake_uuid = mock.MagicMock()
+        fake_uuid.hex = fake_hex
+        with mock.patch("evlib.dataloaders._mvsec_storage.uuid.uuid4", return_value=fake_uuid):
+            _build_event_cache(hdf5_path, DATASET_KEY, cache_dir)
+
+        assert not os.path.isdir(temp_dir)
+        assert os.path.isdir(cache_dir)
+
+
+class TestBuildEventCacheEdgeCases:
+    def test_cleanup_on_error(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_dir = str(tmp_path / "event_cache_err")
+
+        with mock.patch(
+            "evlib.dataloaders._mvsec_storage._copy_event_rows_into_columns",
+            side_effect=IOError("boom"),
+        ):
+            with pytest.raises(IOError):
+                _build_event_cache(hdf5_path, DATASET_KEY, cache_dir)
+        assert not os.path.isdir(cache_dir)
+
+
+class TestLoadMvsecGTFlow:
+    def test_reuses_existing_cache(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=3)
+        cache_root = str(tmp_path / "cache")
+
+        load_mvsec_gt_flow(npz_path, "seq1", cache_root, "cached")
+        x, y, t = load_mvsec_gt_flow(npz_path, "seq1", cache_root, "cached")
+        assert len(t) == 3
+
+    def test_cached_mode(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=3)
+        cache_root = str(tmp_path / "cache")
+
+        x, y, t = load_mvsec_gt_flow(npz_path, "seq1", cache_root, "cached")
+        assert x.dtype == np.float32
+        assert t.dtype == np.float64
+        assert len(t) == 3
+
+    def test_lazy_mode(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=3)
+        cache_root = str(tmp_path / "cache")
+
+        x, y, t = load_mvsec_gt_flow(npz_path, "seq1", cache_root, "lazy")
+        assert len(t) == 3
+
+    def test_falls_back_on_os_error(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        npz_path = str(tmp_path / "flow.npz")
+        _make_gt_flow_npz(npz_path, n_frames=3)
+        cache_root = str(tmp_path / "cache")
+
+        with mock.patch(
+            "evlib.dataloaders._mvsec_storage._make_gt_flow_cache_dir",
+            side_effect=OSError("disk full"),
+        ):
+            x, y, t = load_mvsec_gt_flow(npz_path, "seq1", cache_root, "cached")
+        assert len(t) == 3
+
+
+class TestCopyEventRows:
+    def test_columns_match_rows(self) -> None:
+        n = 10
+        rows = np.zeros((n, 4), dtype=np.float64)
+        rows[:, 0] = np.arange(n)  # x
+        rows[:, 1] = np.arange(n) + 10  # y
+        rows[:, 2] = np.linspace(0, 1, n)  # timestamp
+        rows[:, 3] = np.tile([0.0, 1.0], n // 2)  # polarity
+
+        x = np.empty(n, dtype=np.int16)
+        y = np.empty(n, dtype=np.int16)
+        ts = np.empty(n, dtype=np.float64)
+        pol = np.empty(n, dtype=np.bool_)
+
+        with h5py.File("dummy.hdf5", "w", driver="core", backing_store=False) as f:
+            ds = f.create_dataset("events", data=rows)
+            _copy_event_rows_into_columns(ds, x, y, ts, pol)
+
+        np.testing.assert_array_equal(x, rows[:, 0].astype(np.int16))
+        np.testing.assert_array_equal(y, rows[:, 1].astype(np.int16))
+        expected_pol = rows[:, 3] > 0.0
+        np.testing.assert_array_equal(pol, expected_pol)
+
+
+class TestFreezeEventColumns:
+    def test_marks_readonly(self) -> None:
+        x = np.zeros(5, dtype=np.int16)
+        y = np.zeros(5, dtype=np.int16)
+        ts = np.zeros(5, dtype=np.float64)
+        pol = np.zeros(5, dtype=np.bool_)
+        _freeze_event_columns(x, y, ts, pol)
+        assert not x.flags.writeable
+        assert not y.flags.writeable
+        assert not ts.flags.writeable
+        assert not pol.flags.writeable
+
+
+class TestPrepareEventCache:
+    def test_creates_and_reuses(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_root = str(tmp_path / "cache")
+
+        _, paths1, meta1 = _prepare_event_cache(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        _, paths2, meta2 = _prepare_event_cache(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        assert meta1["num_events"] == meta2["num_events"]
+        assert paths1 == paths2
+
+
+class TestLoadMvsecCachedEvents:
+    def test_loads_frozen_columns(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_root = str(tmp_path / "cache")
+
+        x, y, ts, pol = load_mvsec_cached_events(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        assert len(x) == N_EVENTS
+        assert not x.flags.writeable
+        assert not ts.flags.writeable
+
+
+class TestLazyH5Dataset:
+    def test_read_and_close(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        reader = _LazyH5Dataset(hdf5_path, DATASET_KEY, np.float64)
+
+        assert not reader.has_open_handle
+        row = reader.read(0)
+        assert reader.has_open_handle
+        assert row is not None  # type: ignore[unreachable]
+        assert not row.flags.writeable
+
+        reader.close()
+        assert not reader.has_open_handle
+        result = reader.read(0)
+        assert result is None
+
+    def test_pickle_drops_handles(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        reader = _LazyH5Dataset(hdf5_path, DATASET_KEY, np.float64)
+        reader.read(0)
+
+        state = reader.__getstate__()
+        assert state["_file"] is None
+        assert state["_dataset"] is None
+        assert state["_pid"] is None
+
+    def test_reuses_open_handle(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        reader = _LazyH5Dataset(hdf5_path, DATASET_KEY, np.float64)
+        reader.read(0)
+        reader.read(1)
+        assert reader.has_open_handle
+
+
+class TestCachedEventBackend:
+    def test_from_event_dataset(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        with h5py.File(hdf5_path, "r") as f:
+            backend = _CachedEventBackend.from_event_dataset(f[DATASET_KEY])
+
+        assert backend.num_events == N_EVENTS
+        events = backend.load_events(0, 5)
+        assert len(events) == 5
+
+    def test_from_sidecar(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_root = str(tmp_path / "cache")
+
+        backend = _CachedEventBackend.from_sidecar(
+            hdf5_path, DATASET_KEY, "seq1", "left", cache_root
+        )
+        assert backend.num_events == N_EVENTS
+
+    def test_time_and_index_methods(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        with h5py.File(hdf5_path, "r") as f:
+            backend = _CachedEventBackend.from_event_dataset(f[DATASET_KEY])
+
+        idx = backend.time_to_index(0.5)
+        t = backend.index_to_time(0)
+        assert isinstance(idx, int)
+        assert isinstance(t, float)
+
+        indices = backend.times_to_indices(np.array([0.0, 0.5, 1.0]))
+        assert indices.dtype == np.int64
+
+        times = backend.indices_to_times(np.array([0, 1, 2]))
+        assert times.dtype == np.float64
+
+    def test_close_is_noop(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        with h5py.File(hdf5_path, "r") as f:
+            backend = _CachedEventBackend.from_event_dataset(f[DATASET_KEY])
+        backend.close()
+        assert backend.num_events == N_EVENTS
+
+
+class TestLazyEventBackend:
+    def test_load_events(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_root = str(tmp_path / "cache")
+
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        assert backend.num_events == N_EVENTS
+        events = backend.load_events(0, 5)
+        assert len(events) == 5
+
+    def test_time_and_index_methods(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_root = str(tmp_path / "cache")
+
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        idx = backend.time_to_index(0.5)
+        t = backend.index_to_time(0)
+        assert isinstance(idx, int)
+        assert isinstance(t, float)
+
+        indices = backend.times_to_indices(np.array([0.0, 0.5]))
+        assert indices.dtype == np.int64
+
+        times = backend.indices_to_times(np.array([0, 1]))
+        assert times.dtype == np.float64
+
+    def test_close_releases_memmaps(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_root = str(tmp_path / "cache")
+
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        backend.load_events(0, 1)
+        backend.close()
+        assert backend._x is None
+        assert backend._timestamp is None
+
+    def test_pickle_drops_memmaps(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        hdf5_path = str(tmp_path / "test.hdf5")
+        _make_hdf5(hdf5_path)
+        cache_root = str(tmp_path / "cache")
+
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        backend.load_events(0, 1)
+        state = backend.__getstate__()
+        assert state["_x"] is None
+        assert state["_pid"] is None

--- a/tests/dataloaders/test_mvsec_storage.py
+++ b/tests/dataloaders/test_mvsec_storage.py
@@ -8,30 +8,29 @@ import h5py
 import numpy as np
 import pytest
 
-from evlib.dataloaders._mvsec_storage import ResidentLoadMode
-from evlib.dataloaders._mvsec_storage import _build_event_cache
+from evlib.dataloaders._event_cache import _build_event_cache
+from evlib.dataloaders._event_cache import _CachedEventBackend
+from evlib.dataloaders._event_cache import _copy_event_rows_into_columns
+from evlib.dataloaders._event_cache import _event_cache_is_complete
+from evlib.dataloaders._event_cache import _freeze_event_columns
+from evlib.dataloaders._event_cache import _LazyEventBackend
+from evlib.dataloaders._event_cache import _load_event_cache_metadata
+from evlib.dataloaders._event_cache import _make_cache_signature
+from evlib.dataloaders._event_cache import _make_event_cache_dir
+from evlib.dataloaders._event_cache import _make_event_cache_paths
+from evlib.dataloaders._event_cache import _prepare_event_cache
+from evlib.dataloaders._event_cache import _write_json as _write_event_json
+from evlib.dataloaders._event_cache import load_cached_events
 from evlib.dataloaders._mvsec_storage import _build_gt_flow_cache
-from evlib.dataloaders._mvsec_storage import _CachedEventBackend
-from evlib.dataloaders._mvsec_storage import _copy_event_rows_into_columns
-from evlib.dataloaders._mvsec_storage import _event_cache_is_complete
-from evlib.dataloaders._mvsec_storage import _freeze_event_columns
 from evlib.dataloaders._mvsec_storage import _gt_flow_cache_is_complete
-from evlib.dataloaders._mvsec_storage import _LazyEventBackend
-from evlib.dataloaders._mvsec_storage import _LazyH5Dataset
-from evlib.dataloaders._mvsec_storage import _load_event_cache_metadata
 from evlib.dataloaders._mvsec_storage import _load_gt_flow_cache_metadata
-from evlib.dataloaders._mvsec_storage import _make_cache_signature
-from evlib.dataloaders._mvsec_storage import _make_event_cache_dir
-from evlib.dataloaders._mvsec_storage import _make_event_cache_paths
 from evlib.dataloaders._mvsec_storage import _make_gt_flow_cache_dir
 from evlib.dataloaders._mvsec_storage import _make_gt_flow_cache_paths
-from evlib.dataloaders._mvsec_storage import _prepare_event_cache
-from evlib.dataloaders._mvsec_storage import _write_json
-from evlib.dataloaders._mvsec_storage import load_mvsec_cached_events
+from evlib.dataloaders._mvsec_storage import _write_json as _write_gt_flow_json
 from evlib.dataloaders._mvsec_storage import load_mvsec_gt_flow
-from evlib.dataloaders._mvsec_storage import normalize_resident_load_mode
 from evlib.dataloaders._mvsec_storage import resolve_mvsec_cache_dir
-from evlib.types import RawEvents
+from evlib.dataloaders._storage_common import _LazyH5Dataset
+from evlib.dataloaders._storage_common import normalize_resident_load_mode
 
 
 N_EVENTS = 50
@@ -39,7 +38,7 @@ DATASET_KEY = "davis/left/events"
 
 
 def _make_hdf5(path: str, n_events: int = N_EVENTS) -> None:
-    """minimal MVSEC like HDF5 file."""
+    """Create a minimal MVSEC-like HDF5 file."""
     with h5py.File(path, "w") as f:
         events = np.zeros((n_events, 4), dtype=np.float64)
         events[:, 0] = np.arange(n_events) % 10  # x
@@ -115,7 +114,7 @@ class TestEventCachePaths:
         hdf5_path = str(tmp_path / "test.hdf5")
         _make_hdf5(hdf5_path)
         cache_dir = _make_event_cache_dir(
-            str(tmp_path), hdf5_path, DATASET_KEY, "indoor_flying1", "left"
+            str(tmp_path), hdf5_path, DATASET_KEY, "indoor_flying1_left"
         )
         assert "indoor_flying1_left_" in cache_dir
 
@@ -147,7 +146,7 @@ class TestEventCacheMetadata:
             "num_events": 50,
         }
         path = str(tmp_path / "metadata.json")
-        _write_json(path, metadata)  # type: ignore[arg-type]
+        _write_event_json(path, metadata)  # type: ignore[arg-type]
         loaded = _load_event_cache_metadata(path)
         assert loaded == metadata
 
@@ -179,7 +178,7 @@ class TestEventCacheComplete:
             "source_mtime_ns": stat.st_mtime_ns,
             "num_events": N_EVENTS,
         }
-        _write_json(os.path.join(cache_dir, "metadata.json"), metadata)  # type: ignore[arg-type]
+        _write_event_json(os.path.join(cache_dir, "metadata.json"), metadata)  # type: ignore[arg-type]
         result = _event_cache_is_complete(cache_dir, hdf5_path, DATASET_KEY)
         assert result is None
 
@@ -199,7 +198,7 @@ class TestEventCacheComplete:
             "source_mtime_ns": 0,
             "num_events": N_EVENTS,
         }
-        _write_json(paths["metadata"], metadata)  # type: ignore[arg-type]
+        _write_event_json(paths["metadata"], metadata)  # type: ignore[arg-type]
         result = _event_cache_is_complete(cache_dir, hdf5_path, DATASET_KEY)
         assert result is None
 
@@ -223,7 +222,7 @@ class TestGTFlowCacheComplete:
             "source_size": stat.st_size,
             "source_mtime_ns": stat.st_mtime_ns,
         }
-        _write_json(os.path.join(cache_dir, "metadata.json"), metadata)  # type: ignore[arg-type]
+        _write_gt_flow_json(os.path.join(cache_dir, "metadata.json"), metadata)  # type: ignore[arg-type]
         result = _gt_flow_cache_is_complete(cache_dir, npz_path)
         assert result is None
 
@@ -241,7 +240,7 @@ class TestGTFlowCacheComplete:
             "source_size": 0,
             "source_mtime_ns": 0,
         }
-        _write_json(paths["metadata"], metadata)  # type: ignore[arg-type]
+        _write_gt_flow_json(paths["metadata"], metadata)  # type: ignore[arg-type]
         result = _gt_flow_cache_is_complete(cache_dir, npz_path)
         assert result is None
 
@@ -347,7 +346,7 @@ class TestBuildEventCacheTempDirExists:
 
         fake_uuid = mock.MagicMock()
         fake_uuid.hex = fake_hex
-        with mock.patch("evlib.dataloaders._mvsec_storage.uuid.uuid4", return_value=fake_uuid):
+        with mock.patch("evlib.dataloaders._event_cache.uuid.uuid4", return_value=fake_uuid):
             _build_event_cache(hdf5_path, DATASET_KEY, cache_dir)
 
         assert not os.path.isdir(temp_dir)
@@ -361,7 +360,7 @@ class TestBuildEventCacheEdgeCases:
         cache_dir = str(tmp_path / "event_cache_err")
 
         with mock.patch(
-            "evlib.dataloaders._mvsec_storage._copy_event_rows_into_columns",
+            "evlib.dataloaders._event_cache._copy_event_rows_into_columns",
             side_effect=IOError("boom"),
         ):
             with pytest.raises(IOError):
@@ -453,8 +452,9 @@ class TestPrepareEventCache:
         _make_hdf5(hdf5_path)
         cache_root = str(tmp_path / "cache")
 
-        _, paths1, meta1 = _prepare_event_cache(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
-        _, paths2, meta2 = _prepare_event_cache(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        cache_name = "seq1_left"
+        _, paths1, meta1 = _prepare_event_cache(hdf5_path, DATASET_KEY, cache_name, cache_root)
+        _, paths2, meta2 = _prepare_event_cache(hdf5_path, DATASET_KEY, cache_name, cache_root)
         assert meta1["num_events"] == meta2["num_events"]
         assert paths1 == paths2
 
@@ -465,7 +465,8 @@ class TestLoadMvsecCachedEvents:
         _make_hdf5(hdf5_path)
         cache_root = str(tmp_path / "cache")
 
-        x, y, ts, pol = load_mvsec_cached_events(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        cache_name = "seq1_left"
+        x, y, ts, pol = load_cached_events(hdf5_path, DATASET_KEY, cache_name, cache_root)
         assert len(x) == N_EVENTS
         assert not x.flags.writeable
         assert not ts.flags.writeable
@@ -523,10 +524,9 @@ class TestCachedEventBackend:
         hdf5_path = str(tmp_path / "test.hdf5")
         _make_hdf5(hdf5_path)
         cache_root = str(tmp_path / "cache")
+        cache_name = "seq1_left"
 
-        backend = _CachedEventBackend.from_sidecar(
-            hdf5_path, DATASET_KEY, "seq1", "left", cache_root
-        )
+        backend = _CachedEventBackend.from_sidecar(hdf5_path, DATASET_KEY, cache_name, cache_root)
         assert backend.num_events == N_EVENTS
 
     def test_time_and_index_methods(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
@@ -560,8 +560,9 @@ class TestLazyEventBackend:
         hdf5_path = str(tmp_path / "test.hdf5")
         _make_hdf5(hdf5_path)
         cache_root = str(tmp_path / "cache")
+        cache_name = "seq1_left"
 
-        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, cache_name, cache_root)
         assert backend.num_events == N_EVENTS
         events = backend.load_events(0, 5)
         assert len(events) == 5
@@ -570,8 +571,9 @@ class TestLazyEventBackend:
         hdf5_path = str(tmp_path / "test.hdf5")
         _make_hdf5(hdf5_path)
         cache_root = str(tmp_path / "cache")
+        cache_name = "seq1_left"
 
-        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, cache_name, cache_root)
         idx = backend.time_to_index(0.5)
         t = backend.index_to_time(0)
         assert isinstance(idx, int)
@@ -587,8 +589,9 @@ class TestLazyEventBackend:
         hdf5_path = str(tmp_path / "test.hdf5")
         _make_hdf5(hdf5_path)
         cache_root = str(tmp_path / "cache")
+        cache_name = "seq1_left"
 
-        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, cache_name, cache_root)
         backend.load_events(0, 1)
         backend.close()
         assert backend._x is None
@@ -598,8 +601,9 @@ class TestLazyEventBackend:
         hdf5_path = str(tmp_path / "test.hdf5")
         _make_hdf5(hdf5_path)
         cache_root = str(tmp_path / "cache")
+        cache_name = "seq1_left"
 
-        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, "seq1", "left", cache_root)
+        backend = _LazyEventBackend(hdf5_path, DATASET_KEY, cache_name, cache_root)
         backend.load_events(0, 1)
         state = backend.__getstate__()
         assert state["_x"] is None

--- a/tests/dataloaders/test_mvsec_storage.py
+++ b/tests/dataloaders/test_mvsec_storage.py
@@ -8,6 +8,7 @@ import h5py
 import numpy as np
 import pytest
 
+from evlib.dataloaders import LoadingType
 from evlib.dataloaders._event_cache import _build_event_cache
 from evlib.dataloaders._event_cache import _CachedEventBackend
 from evlib.dataloaders._event_cache import _copy_event_rows_into_columns
@@ -30,8 +31,6 @@ from evlib.dataloaders._mvsec_storage import _write_json as _write_gt_flow_json
 from evlib.dataloaders._mvsec_storage import load_mvsec_gt_flow
 from evlib.dataloaders._mvsec_storage import resolve_mvsec_cache_dir
 from evlib.dataloaders._storage_common import _LazyH5Dataset
-from evlib.dataloaders._storage_common import normalize_resident_load_mode
-
 
 N_EVENTS = 50
 DATASET_KEY = "davis/left/events"
@@ -59,18 +58,26 @@ def _make_gt_flow_npz(path: str, n_frames: int = 5) -> None:
     )
 
 
-class TestNormalizeResidentLoadMode:
+class TestLoadingType:
     def test_cached(self) -> None:
-        result = normalize_resident_load_mode("events", "cached")
-        assert result == "cached"
+        result = LoadingType.from_resident_value("cached", name="events")
+        assert result is LoadingType.CACHED
 
     def test_lazy(self) -> None:
-        result = normalize_resident_load_mode("events", "lazy")
-        assert result == "lazy"
+        result = LoadingType.from_resident_value("lazy", name="events")
+        assert result is LoadingType.LAZY
+
+    def test_from_resident_enum(self) -> None:
+        result = LoadingType.from_resident_value(LoadingType.LAZY, name="events")
+        assert result is LoadingType.LAZY
+
+    def test_bool_is_invalid_for_resident_mode(self) -> None:
+        with pytest.raises(ValueError, match="events must be"):
+            LoadingType.from_resident_value(True, name="events")  # type: ignore[arg-type]
 
     def test_invalid_raises(self) -> None:
         with pytest.raises(ValueError, match="events must be"):
-            normalize_resident_load_mode("events", "invalid")
+            LoadingType.from_resident_value("invalid", name="events")  # type: ignore[arg-type]
 
 
 class TestResolveCacheDir:

--- a/tests/dataloaders/test_mvsec_types.py
+++ b/tests/dataloaders/test_mvsec_types.py
@@ -1,5 +1,3 @@
-"""Tests for MVSEC types."""
-
 import numpy as np
 
 from evlib.dataloaders._mvsec_types import MVSECOdometryData

--- a/tests/dataloaders/test_mvsec_types.py
+++ b/tests/dataloaders/test_mvsec_types.py
@@ -1,0 +1,42 @@
+"""Tests for MVSEC types."""
+
+import numpy as np
+
+from evlib.dataloaders._mvsec_types import MVSECOdometryData
+
+
+class TestMVSECOdometryData:
+    def test_fields(self) -> None:
+        odom = MVSECOdometryData(
+            timestamps=np.array([0.0, 1.0], dtype=np.float64),
+            linear_velocity=np.zeros((2, 3), dtype=np.float64),
+            position=np.zeros((2, 3), dtype=np.float64),
+            quaternion=np.zeros((2, 4), dtype=np.float64),
+            angular_velocity=np.zeros((2, 3), dtype=np.float64),
+        )
+        assert odom.timestamps.shape == (2,)
+        assert odom.linear_velocity.shape == (2, 3)
+
+    def test_len(self) -> None:
+        odom = MVSECOdometryData(
+            timestamps=np.array([0.0, 1.0, 2.0], dtype=np.float64),
+            linear_velocity=np.zeros((3, 3), dtype=np.float64),
+            position=np.zeros((3, 3), dtype=np.float64),
+            quaternion=np.zeros((3, 4), dtype=np.float64),
+            angular_velocity=np.zeros((3, 3), dtype=np.float64),
+        )
+        assert len(odom) == 3
+
+    def test_frozen(self) -> None:
+        odom = MVSECOdometryData(
+            timestamps=np.array([0.0], dtype=np.float64),
+            linear_velocity=np.zeros((1, 3), dtype=np.float64),
+            position=np.zeros((1, 3), dtype=np.float64),
+            quaternion=np.zeros((1, 4), dtype=np.float64),
+            angular_velocity=np.zeros((1, 3), dtype=np.float64),
+        )
+        try:
+            odom.timestamps = np.array([1.0])  # type: ignore[misc]
+            assert False, "Should have raised"
+        except AttributeError:
+            pass


### PR DESCRIPTION
 Adds the full MVSEC dataloader implementation:

  - `_mvsec_types.py` - Frozen `MVSECOdometryData` dataclass
  - `_mvsec_storage.py` - Content addressed persistent sidecar caches for HDF5 events and GT flow, with two event backends for in memory `CachedEventBackend`, and mmap based `LazyEventBackend`)
  - `_mvsec.py` - `MVSECDataLoader` implementing `DataLoaderBase` for all MVSEC modalities (events, images, IMU, odometry, depth, optical flow, velodyne) with configurable per modality load modes


  This is a large PR, can try to breakup if needed. 
An overview of things to look at:

  1. **`_mvsec_types.py`** (21 lines) - trivial frozen dataclass for odometry 
  2. **`_mvsec_storage.py`** (~700 lines) - self contained caching layer with no public API. Start with `_make_cache_signature` (content addressing scheme), then `_build_event_cache` (atomic temp dir + rename pattern), then the two backend classes at the bottom
  3. **`_mvsec.py`** (~1300 lines) - the main class. `__init__`  are where all modalities are loaded (lines 400-650), then the `DataLoaderBase` interface methods, then rest are the property accessors (mostly trivial one liners)


  Design decisions:

  - Events are stored as typed columns (x/y/t/p) not row tuples, for cache friendly access
  - Sidecar caches use atomic rename (build in temp dir, `os.replace`) so readers never see partial writes
  - HDF5 handles are not safe across `fork()`, so lazy readers track PID and reopen after fork/unpickle
  - Large HDF5 reads are streamed in 1M row blocks to bound peak memory

  ## Tests

100% coverage for all except `_mvsec.py` which has 78%, uncovered lines are optional modality accessors. 151 tests total

---
Next will follow MVSECDataset for PyTorch compatible map/iterable style dataset wrappers that use this dataloader. 