### PR TITLE
Add python 3.12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,21 @@ jobs:
         include:
           # - { python: "3.10", os: "ubuntu-latest", session: "pre-commit" }
           # mypy
+          - { python: "3.12", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.11", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.10", os: "ubuntu-latest", session: "mypy" }
           # - { python: "3.9", os: "ubuntu-latest", session: "mypy" }
           # - { python: "3.8", os: "ubuntu-latest", session: "mypy" }
           # - { python: "3.7", os: "ubuntu-22.04", session: "mypy" }
           # test
+          - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
           - { python: "3.9", os: "ubuntu-latest", session: "tests" }
           - { python: "3.8", os: "ubuntu-latest", session: "tests" }
           # - { python: "3.7", os: "ubuntu-22.04", session: "tests" }
           # mac
+          - { python: "3.12", os: "macos-latest", session: "tests" }
           - { python: "3.11", os: "macos-latest", session: "tests" }
           - { python: "3.10", os: "macos-latest", session: "tests" }
           - { python: "3.9", os: "macos-latest", session: "tests" }
@@ -53,7 +56,7 @@ jobs:
       - name: Free disk space
         # Make sure to provide the relative path to `free-disk-space`
         uses: ./ci-actions/actions/free-disk-space
-        
+
       - name: Check out the repository
         uses: actions/checkout@v6
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please see our [examples](https://github.com/shiba24/event-vision-library/tree/m
 
 ## Features
 
-- Python 3.8, 3.9, 3.10, 3.11
+- Python 3.8, 3.9, 3.10, 3.11, 3.12
 - Pure-python library
 - Numpy and Torch compatibility.
 - 🚧 This library is under construction and currently alpha version. The APIs may change significantly. Contributions and discussions are welcomed! 🚧

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 pip install event-vision-library
 ```
 
-The supported python versions are 3.8. 3.9, 3.10, and 3.11.
+The supported python versions are 3.8, 3.9, 3.10, 3.11, and 3.12.
 
 ## Examples
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 package = "evlib"
-python_versions = ["3.10", "3.11", "3.9", "3.8"]  # 3.10 is the default
+python_versions = ["3.10", "3.12", "3.11", "3.9", "3.8"]  # 3.10 is the default
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     # "pre-commit",

--- a/poetry.lock
+++ b/poetry.lock
@@ -1009,7 +1009,7 @@ description = "Python library for calculating contours of 2D quadrilateral grids
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version == \"3.11\""
+markers = "python_version >= \"3.11\""
 files = [
     {file = "contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1"},
     {file = "contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381"},
@@ -3839,7 +3839,7 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = false
 python-versions = "!=3.14.1,>=3.11"
 groups = ["main"]
-markers = "python_version == \"3.11\""
+markers = "python_version >= \"3.11\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -4381,6 +4381,7 @@ numpy = [
     {version = ">=1.21.4", markers = "python_version == \"3.10\" and platform_system == \"Darwin\""},
     {version = ">=1.21.0", markers = "python_version == \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
     {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 
 [[package]]
@@ -5459,7 +5460,7 @@ description = "Manipulate well-formed Roman numerals"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
-markers = "python_version == \"3.11\""
+markers = "python_version >= \"3.11\""
 files = [
     {file = "roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c"},
     {file = "roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d"},
@@ -5821,7 +5822,7 @@ description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version == \"3.11\""
+markers = "python_version >= \"3.11\""
 files = [
     {file = "scipy-1.16.3-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:40be6cf99e68b6c4321e9f8782e7d5ff8265af28ef2cd56e9c9b2638fa08ad97"},
     {file = "scipy-1.16.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:8be1ca9170fcb6223cc7c27f4305d680ded114a1567c0bd2bfcbf947d1b17511"},
@@ -6107,7 +6108,7 @@ description = "Python documentation generator"
 optional = false
 python-versions = ">=3.11"
 groups = ["dev"]
-markers = "python_version == \"3.11\""
+markers = "python_version >= \"3.11\""
 files = [
     {file = "sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3"},
     {file = "sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348"},
@@ -6189,7 +6190,7 @@ description = "Rebuild Sphinx documentation on changes, with hot reloading in th
 optional = false
 python-versions = ">=3.11"
 groups = ["dev"]
-markers = "python_version == \"3.11\""
+markers = "python_version >= \"3.11\""
 files = [
     {file = "sphinx_autobuild-2025.8.25-py3-none-any.whl", hash = "sha256:b750ac7d5a18603e4665294323fd20f6dcc0a984117026d1986704fa68f0379a"},
     {file = "sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213"},
@@ -6831,6 +6832,7 @@ nvidia-nccl-cu12 = {version = "2.27.5", markers = "platform_system == \"Linux\" 
 nvidia-nvjitlink-cu12 = {version = "12.8.93", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-nvshmem-cu12 = {version = "3.3.20", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-nvtx-cu12 = {version = "12.8.90", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+setuptools = {version = "*", markers = "python_version >= \"3.12\""}
 sympy = ">=1.13.3"
 triton = {version = "3.5.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 typing-extensions = ">=4.10.0"
@@ -7709,5 +7711,5 @@ ros = ["rosbags", "rosbags"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.8,<3.12"
-content-hash = "e59a99e71c71d06fb572f8e893d15ec02810056a1c8a6b5b091a179b31af1476"
+python-versions = ">=3.8,<3.13"
+content-hash = "ced40b404642deb05a2503be62ddbf253742c636994d098b1a302ecb716ee5d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,15 @@ classifiers = [
 Changelog = "https://github.com/shiba24/event-vision-library/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<3.13"
 click = ">=8.0.1"
 setuptools = [
-    {version = ">=79.0.0", python = ">=3.9,<3.12"},
+    {version = ">=79.0.0", python = ">=3.9,<3.13"},
     {version = "<75.4.0", python = "==3.8"},
 ]
 wheel = ">=0.38.4"
 numpy = [
-    {version = ">=1.26.4,<2.0", python = ">=3.9,<3.12"},
+    {version = ">=1.26.4,<2.0", python = ">=3.9,<3.13"},
     {version = ">=1.24.0", python = "==3.8"}
 ]
 h5py = ">=3.2"
@@ -47,10 +47,12 @@ rosbags = [
     {version = ">=0.11,<0.12", python = ">=3.10", optional = true},
 ]
 scipy = [
-    {version = ">=1.9.1", python = ">=3.8,<3.12"}
+    {version = ">=1.9.1", python = ">=3.8,<3.12"},
+    {version = ">=1.11.2", python = ">=3.12,<3.13"}
 ]  # TODO check newer version of scipy
 torch = [
     {version = ">=2.0.0", python = ">=3.9,<3.12"},
+    {version = ">=2.2.0", python = ">=3.12,<3.13"},
     {version = "<2.5", python = "==3.8"}
 ]  # TODO check newer version of torch
 # check https://github.com/python-poetry/poetry/issues/6409 and https://github.com/pytorch/pytorch/issues/76557


### PR DESCRIPTION
Add Python 3.12 support now that `dv` is no longer a dependency. 

- Raise `numpy`/`setuptools` upper bounds to <3.13, `scipy` (>=1.11.2) and `torch` (>=2.2.0) - which are the first releases with 3.12 wheels
- Relevant noxfile.py and github workflow Python 3.12 tests/mypy matrix added
- Update README.md