### PR TITLE
Update readthedocs python to 3.11 and requirements.txt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,8 @@ jobs:
           - { python: "3.10", os: "macos-latest", session: "tests" }
           - { python: "3.9", os: "macos-latest", session: "tests" }
           # docs
-          - { python: "3.10", os: "ubuntu-latest", session: "xdoctest" }
-          - { python: "3.10", os: "ubuntu-latest", session: "docs-build" }
+          - { python: "3.11", os: "ubuntu-latest", session: "xdoctest" }
+          - { python: "3.11", os: "ubuntu-latest", session: "docs-build" }
 
     env:
       NOXSESSION: ${{ matrix.session }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.10"
+    python: "3.11"
 sphinx:
   configuration: docs/conf.py
 formats: all

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-furo==2024.8.6
-sphinx==9.0.4
-sphinx-click==6.0.0
-myst_parser==4.0.1
+furo
+sphinx
+sphinx-click
+myst_parser

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 furo
 sphinx
 sphinx-click
-myst_parser
+myst-parser

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 package = "evlib"
-python_versions = ["3.10", "3.12", "3.11", "3.9", "3.8"]  # 3.10 is the default
+python_versions = ["3.11", "3.12", "3.10", "3.9", "3.8"]  # 3.11 is the default
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     # "pre-commit",


### PR DESCRIPTION
- Change the default python version from 3.10 to 3.11, affecting docs and precommit-hook
- Fix broken docs pipeline. Now you can see at: https://event-vision-library.readthedocs.io/en/feat-update-readthedocs-config/index.html
- Relax the docs/requirements
- Update CI