### PR TITLE
Replace expelliarmus dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1512,74 +1512,6 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "expelliarmus"
-version = "1.1.12"
-description = ""
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "expelliarmus-1.1.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6040a4cee3f84499763a999e5797e608e968c0473f48c11482275476f6c3c27f"},
-    {file = "expelliarmus-1.1.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eed18bb32bccc582d1d3abf47daffba65aaa23960fb105d35a4ab222fda8bcbc"},
-    {file = "expelliarmus-1.1.12-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff81b8afe170d1b365a2efb155361d01899429710357151f0447735f460319fb"},
-    {file = "expelliarmus-1.1.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ae88761817363d0fc2cb427e1e4603b034dd1a8aa7953d18ff82fd3bf9c618a5"},
-    {file = "expelliarmus-1.1.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4994b4ce5f690198dc2b86b3e51fdb51d8459e4940340132b55d7c54f94f1338"},
-    {file = "expelliarmus-1.1.12-cp310-cp310-win32.whl", hash = "sha256:adc91cf689760acc56d1d8c8b35d1c1f94bb3195dbaa117c5287eba081b30569"},
-    {file = "expelliarmus-1.1.12-cp310-cp310-win_amd64.whl", hash = "sha256:26e00512c24f5e7791435097829f39d9f38fbeba46b797607049ee2b22c42895"},
-    {file = "expelliarmus-1.1.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4dc76e2e395274bf195c3f5ebe0eb14b84deed63fb41c9e2d6ba6a6d00efd5c8"},
-    {file = "expelliarmus-1.1.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:260dcec354a94136478e91ff307302472fd9e072c83409afc162f7bbca717a4e"},
-    {file = "expelliarmus-1.1.12-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3af2892ae68546630260a09292ccdd21dd23399a1e4ac8dfd7fc91dc34f2e4ce"},
-    {file = "expelliarmus-1.1.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:84196b48cec9eab9a8f56c7dfe6fca6fd23fd36a5d644b186674bb56ce1dd0be"},
-    {file = "expelliarmus-1.1.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8a2e4d69de9d650ad29dca0d2aed25d4900a08610d800b87b3eead087b422dc7"},
-    {file = "expelliarmus-1.1.12-cp311-cp311-win32.whl", hash = "sha256:0f3dc9943d9f1ca8c3fa2ba4278dae9b524f649b9f7505251d247d3fe55e5b65"},
-    {file = "expelliarmus-1.1.12-cp311-cp311-win_amd64.whl", hash = "sha256:ca8709dfebf869c80c54b9e31b42f64844268c0d6c263d9f33dbecd685d4e6bc"},
-    {file = "expelliarmus-1.1.12-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3455efc4347b7c2aa50525e815f221f7b4cd047048119b19e860d6e8c8df3891"},
-    {file = "expelliarmus-1.1.12-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10e1687ba9da47087dc3dc58da3e0c0f33b73553702f6bca54b0a267a50e088f"},
-    {file = "expelliarmus-1.1.12-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7af216be7be2215578b8c83394b316018899de4f985bed96b9971799766f0251"},
-    {file = "expelliarmus-1.1.12-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:a1aee7e715ffa04f15f1c4742733931dcaeb6023f469569278bb8f51737ec8c4"},
-    {file = "expelliarmus-1.1.12-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e40175be46ac050c49a74b6b82f97758c2be7875c4e76c49f1682d74a01f608b"},
-    {file = "expelliarmus-1.1.12-cp36-cp36m-win32.whl", hash = "sha256:68eaf0006952108807d850201af0579ab26395cf49ca422127cb4a96392ad521"},
-    {file = "expelliarmus-1.1.12-cp36-cp36m-win_amd64.whl", hash = "sha256:7efe3b7f9a093f17a2a1d5b7a5918ad5eb9f18889a086b075da03514e34d6dfc"},
-    {file = "expelliarmus-1.1.12-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1247219882845320399dd576cfac3be71a93677cb15e18ab942167e125b36abf"},
-    {file = "expelliarmus-1.1.12-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0c58f5c38afabe39121a431b03841742b39edcf693df77aa13add7849e77d67"},
-    {file = "expelliarmus-1.1.12-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5227aae90755382f303cdbca85a080e9895ea323ae02722fedb4e480c5755a1e"},
-    {file = "expelliarmus-1.1.12-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c6b628a19361fb14571372aea91089dd1be21ae757345c4eaf32bbf289f158dd"},
-    {file = "expelliarmus-1.1.12-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:cfcc347ca7e006fa60bc4089f61ed715beb33db2389b7e224d196793d2e506fe"},
-    {file = "expelliarmus-1.1.12-cp37-cp37m-win32.whl", hash = "sha256:0eb810e07a89f1ca99f8c3e8232de152b7106f7f44681c84999a5fbc6c75bcaa"},
-    {file = "expelliarmus-1.1.12-cp37-cp37m-win_amd64.whl", hash = "sha256:4c056db3c42fe130a988ef8f88a3c04379a1e84a23f64471ec772e5d88fbb351"},
-    {file = "expelliarmus-1.1.12-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2bbf4840885838f75dafa6e80cac6cdab897a92e5c475e5e28e27b43ca03238b"},
-    {file = "expelliarmus-1.1.12-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2958594ce0bfcf7a31e0e58ec092f7260fdee2efc67814c74bcbe2c4c3b91bc5"},
-    {file = "expelliarmus-1.1.12-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f9dcb57efa2f8a418a1fca99944113a408122781212f11514f63cd19f22bbb1"},
-    {file = "expelliarmus-1.1.12-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b9a542e247657e6f46b390ef4f60d450fc2cfe195f14b2851c3861ea9f2db611"},
-    {file = "expelliarmus-1.1.12-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7cf8103cc49db59f6d4a55f9dc839063a50e9dcae47f8fd371118aba8ac64916"},
-    {file = "expelliarmus-1.1.12-cp38-cp38-win32.whl", hash = "sha256:8d93a8fdf7087d51a3e0070dfeabaf1c1910f8d5ac9240473d9ab9597671b077"},
-    {file = "expelliarmus-1.1.12-cp38-cp38-win_amd64.whl", hash = "sha256:a88f4581c50e0f020365f7f4a84b0f9196dff8cfa68d85a3ee26eb245c551e75"},
-    {file = "expelliarmus-1.1.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e46652153b92aa44081ee2ff899535d3e522f9a4ab01872ac43c39262278512d"},
-    {file = "expelliarmus-1.1.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:731deb3d2f4d5045d58eeeb5c1ac02a9429e24f4cbc46bf3d6300c8f362280b4"},
-    {file = "expelliarmus-1.1.12-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4967f5ce1b2798fce480f445b9f9d5708dec7a7f456206a3d4b30acbdcc921e"},
-    {file = "expelliarmus-1.1.12-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:35fc80d99e1b17782a1b90d038adf180012daa347ea4d86734809f58c48d0627"},
-    {file = "expelliarmus-1.1.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3580193c91a5c54042baef0c17093939b4c511362becf61552d9f1d0320b9329"},
-    {file = "expelliarmus-1.1.12-cp39-cp39-win32.whl", hash = "sha256:ade588c2cd912d8b159a50a1275b508cb928eb185180969f35a350b523d9107e"},
-    {file = "expelliarmus-1.1.12-cp39-cp39-win_amd64.whl", hash = "sha256:3838e1c4e97e8ae102c305d6dbacee78bb6ed1c3fe33936e6d7a54764b0a230f"},
-    {file = "expelliarmus-1.1.12-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7469b16333bf565006d2dc97aecb0c03d893df63f212641a5ea575ff0a65fde8"},
-    {file = "expelliarmus-1.1.12-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee48190e2d9c04c9159976ea73586f7a46f5b860476f65fc34a5c31685b352f8"},
-    {file = "expelliarmus-1.1.12-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e42adbe723d1dbc99bf8cd37bd339cb14db6cbbf81c479ea4bf71404650aea29"},
-    {file = "expelliarmus-1.1.12-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:9ea7403d177058bad6f336012056b8a9b76cfbaaf1a3eb09a323f9292ca88963"},
-    {file = "expelliarmus-1.1.12-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:01749ac685af1b91d6e4f60ba2481fb73021baf393d4a19969447b8cc1730da6"},
-    {file = "expelliarmus-1.1.12-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:338597a86e6dbade129620db32e45077a719265d69d50f1f1901247b14c76319"},
-    {file = "expelliarmus-1.1.12-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ef424427a6f84d6a0abba5108c870f0bf7696946485c46f64137372875a9459"},
-    {file = "expelliarmus-1.1.12-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:5f18d88f745b3088d60de450c9b83b20bb73957b7dae7984acfafaf4353e2d7e"},
-    {file = "expelliarmus-1.1.12-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b8966c9841335ffbd91a085191963446b48240a7d649a7b65c227873b9c05209"},
-    {file = "expelliarmus-1.1.12-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a726c0f8682ee31472c47988ad5d1577821eee4fb52d6a7466eb878ed4385e6c"},
-    {file = "expelliarmus-1.1.12-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa2a25828f4636fd55516f3767d772bef8c3cad2cd6b5dc3677d72ebfde8b022"},
-    {file = "expelliarmus-1.1.12-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:9fbbf71ac889a8d33198be2081740d344fd8ce8496d0e3c98168dc46dfddf93d"},
-    {file = "expelliarmus-1.1.12.tar.gz", hash = "sha256:69978d115af857016b82a78387a4d78ee952ed802998b9cf778feb80393d2c3d"},
-]
-
-[package.dependencies]
-numpy = "*"
-
-[[package]]
 name = "filelock"
 version = "3.16.1"
 description = "A platform independent file lock."
@@ -7712,4 +7644,4 @@ ros = ["rosbags", "rosbags"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.13"
-content-hash = "ced40b404642deb05a2503be62ddbf253742c636994d098b1a302ecb716ee5d8"
+content-hash = "39fbb1ae0fcbaefefbb801e1a012bc242d2e972eb3f29a82b791c31827a953b3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ numpy = [
 ]
 h5py = ">=3.2"
 hdf5plugin = ">=4.4,<6.0"
-expelliarmus = ">=1.1.12"
 defusedxml = ">=0.7.1"
 lz4 = ">=4.3.3"
 zstd = ">=1.5.7"

--- a/src/evlib/codec/fileformat/_evt3.py
+++ b/src/evlib/codec/fileformat/_evt3.py
@@ -1,0 +1,761 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+from typing import Iterator
+
+import numpy as np
+import numpy.typing as npt
+
+
+_HEADER_PREFIX = b"% "
+# 64kb blocks seem to bench fastest for the NumPy decoder
+_DEFAULT_READ_SIZE = 64 << 10
+_UINT16_SIZE = 2
+
+# Each EVT3 word is a 16bit little endian value:
+#   top nibble - the word type
+#   low 12 bits - payload
+# These are the wordtype codes
+_EVT_ADDR_Y = 0x0
+_EVT_ADDR_X = 0x2
+_VECT_BASE_X = 0x3
+_VECT_12 = 0x4
+_VECT_8 = 0x5
+_EVT_TIME_LOW = 0x6
+_EVT_TIME_HIGH = 0x8
+
+_PAYLOAD_MASK = 0x0FFF  # low 12 bits
+_ADDRESS_MASK = 0x07FF  # low 11 bits: an X or Y coordinate
+_POLARITY_BIT = 0x0800  # bit 11 of an address word
+_VECTOR_8_MASK = 0x00FF  # VECT_8 stores its mask in the low 8 bits
+_TIME_LOW_RANGE = 1 << 12  # time-low wraps every 4096 ticks
+_TIME_HIGH_RANGE_US = 1 << 24  # time-high wraps every 2**24 us
+
+
+def _build_vector_tables(
+    vector_size: int,
+) -> tuple[npt.NDArray[np.uint8], npt.NDArray[np.int32]]:
+    # For every possible vector bitmask
+    # precompute how many bits are set (counts) and which bit positions are set (offsets)
+    # The decoder then expands a vector word with a table lookup instead of per bit work
+    counts = np.empty((1 << vector_size,), dtype=np.uint8)
+    offsets = np.zeros((1 << vector_size, vector_size), dtype=np.int32)
+    for mask in range(1 << vector_size):
+        set_bit_offsets = []
+        for bit_index in range(vector_size):
+            if mask & (1 << bit_index):
+                set_bit_offsets.append(bit_index)
+
+        offset_count = len(set_bit_offsets)
+        counts[mask] = offset_count
+        if offset_count:
+            offsets[mask, :offset_count] = set_bit_offsets
+    return counts, offsets
+
+
+_VECTOR_8_COUNTS, _VECTOR_8_OFFSETS = _build_vector_tables(8)
+_VECTOR_12_COUNTS, _VECTOR_12_OFFSETS = _build_vector_tables(12)
+_VECTOR_8_INDEXES = np.arange(8, dtype=np.int64)
+_VECTOR_12_INDEXES = np.arange(12, dtype=np.int64)
+
+
+class Evt3RawError(RuntimeError):
+    """Raised when an EVT3 RAW file cannot be decoded."""
+
+
+@dataclass(frozen=True)
+class Evt3EventChunk:
+    """Decoded EVT3 CD event chunk."""
+
+    t: npt.NDArray[np.float64]
+    x: npt.NDArray[np.int32]
+    y: npt.NDArray[np.int32]
+    p: npt.NDArray[np.bool_]
+
+    def __len__(self) -> int:
+        """Return the number of decoded CD events."""
+        return len(self.t)
+
+
+@dataclass(frozen=True)
+class _DecodedEventBlock:
+    t: npt.NDArray[np.float64]
+    x: npt.NDArray[np.int32]
+    y: npt.NDArray[np.int32]
+    p: npt.NDArray[np.bool_]
+    ends_word: npt.NDArray[np.bool_]
+
+    def __len__(self) -> int:
+        return len(self.t)
+
+    def slice(self, start: int, stop: int) -> Evt3EventChunk:
+        return Evt3EventChunk(
+            t=self.t[start:stop],
+            x=self.x[start:stop],
+            y=self.y[start:stop],
+            p=self.p[start:stop],
+        )
+
+
+@dataclass
+class _Evt3State:
+    y: int = 0
+    base_x: int = 0
+    vector_polarity: bool = False
+    time_high: int = 0
+    time_low: int = 0
+    time_high_overflow: int = 0
+    time_low_overflow: int = 0
+
+    @property
+    def timestamp(self) -> int:
+        return (
+            self.time_high_overflow
+            + self.time_low_overflow
+            + (self.time_high << 12)
+            + self.time_low
+        )
+
+
+class Evt3RawReader:
+    """Streaming decoder for the Prophesee EVT3 RAW subset.
+
+    The reader decodes CD events from EVT3 event stream RAW files. It handles
+    RAW ASCII headers and the EVT3 words that produce CD events:
+    Y addresses, single X events, vector bases, vector events, and timestamp
+    high/low updates.
+    """
+
+    def __init__(
+        self,
+        file_name: str | Path,
+        *,
+        chunk_size: int = 16384,
+        read_size: int = _DEFAULT_READ_SIZE,
+    ) -> None:
+        """Open an EVT3 RAW file.
+
+        Args:
+            file_name: Path to a Prophesee EVT3 ``.raw`` file.
+            chunk_size: Target number of CD events per decoded chunk.
+            read_size: Number of encoded bytes to read per internal block.
+
+        Raises:
+            ValueError: If chunk or read sizes are invalid.
+        """
+        if chunk_size <= 0:
+            raise ValueError("EVT3 chunk_size must be positive")
+        if read_size <= 0:
+            raise ValueError("EVT3 read_size must be positive")
+
+        self.file_name = str(file_name)
+        self.chunk_size = chunk_size
+        self.read_size = read_size
+        self.file: BinaryIO = open(self.file_name, "rb")
+        self.header = self._read_raw_header()
+        self.data_offset = self.file.tell()
+        self.state = _Evt3State()
+        self._decode_initial_state = _Evt3State()
+        self._event_block = self._empty_event_block()
+        self._event_index = 0
+        self._pending_byte = b""
+        self._finished = False
+
+    def close(self) -> None:
+        """Close the underlying file handle."""
+        self.file.close()
+
+    def reset(self) -> None:
+        """Reset decoding to the first encoded word."""
+        self.file.seek(self.data_offset)
+        self.state = _Evt3State()
+        self._decode_initial_state = _Evt3State()
+        self._event_block = self._empty_event_block()
+        self._event_index = 0
+        self._pending_byte = b""
+        self._finished = False
+
+    def read_chunks(self) -> Iterator[Evt3EventChunk]:
+        """Yield decoded CD events in chunks."""
+        while True:
+            try:
+                yield self.next_chunk()
+            except StopIteration:
+                return
+
+    def next_chunk(self) -> Evt3EventChunk:
+        """Return the next decoded CD event chunk.
+
+        Returns:
+            The next decoded CD event chunk.
+
+        Raises:
+            StopIteration: When the file has no more CD events.
+        """
+        slices: list[Evt3EventChunk] = []
+        event_count = 0
+
+        while event_count < self.chunk_size:
+            if self._event_index >= len(self._event_block):
+                if not self._load_decoded_event_block():
+                    if event_count == 0:
+                        raise StopIteration
+                    break
+
+            block = self._event_block
+            start = self._event_index
+            remaining = self.chunk_size - event_count
+            stop = min(start + remaining, len(block))
+
+            # Never split a vector's events across chunks,
+            # extend to the next word boundary even if it slightly overshoots chunk_size
+            if stop < len(block) and stop > start:
+                while stop < len(block) and not block.ends_word[stop - 1]:
+                    stop += 1
+
+            slices.append(block.slice(start, stop))
+            self._event_index = stop
+            event_count += stop - start
+
+        if len(slices) == 1:
+            return slices[0]
+
+        return Evt3EventChunk(
+            t=np.concatenate([chunk.t for chunk in slices]),
+            x=np.concatenate([chunk.x for chunk in slices]),
+            y=np.concatenate([chunk.y for chunk in slices]),
+            p=np.concatenate([chunk.p for chunk in slices]),
+        )
+
+    def _read_raw_header(self) -> dict[str, str]:
+        header: dict[str, str] = {}
+        while True:
+            line_start = self.file.tell()
+            line = self.file.readline()
+            if not line:
+                self._validate_header(header)
+                return header
+            if not line.startswith(_HEADER_PREFIX):
+                self.file.seek(line_start)
+                self._validate_header(header)
+                return header
+
+            decoded_line = line[2:].decode("ascii", errors="replace").strip()
+            if decoded_line == "end":
+                self._validate_header(header)
+                return header
+            key, _, value = decoded_line.partition(" ")
+            header[key] = value
+
+    @staticmethod
+    def _validate_header(header: dict[str, str]) -> None:
+        if not header:
+            return
+
+        format_value = header.get("format", "")
+        evt_value = header.get("evt", "")
+        if "EVT3" in format_value.upper():
+            return
+        if evt_value.strip() in {"3", "3.0"}:
+            return
+        if format_value or evt_value:
+            raise Evt3RawError(
+                "Only Prophesee EVT3 RAW event streams are supported by IteratorEvk3"
+            )
+
+    @staticmethod
+    def _empty_event_block() -> _DecodedEventBlock:
+        return _DecodedEventBlock(
+            t=np.empty((0,), dtype=np.float64),
+            x=np.empty((0,), dtype=np.int32),
+            y=np.empty((0,), dtype=np.int32),
+            p=np.empty((0,), dtype=np.bool_),
+            ends_word=np.empty((0,), dtype=np.bool_),
+        )
+
+    def _load_decoded_event_block(self) -> bool:
+        if self._finished:
+            return False
+
+        while True:
+            words = self._read_word_block()
+            if words is None:
+                return False
+
+            block = self._decode_word_block(words)
+            if len(block) > 0:
+                self._event_block = block
+                self._event_index = 0
+                return True
+
+    def _read_word_block(self) -> npt.NDArray[np.uint16] | None:
+        data = self.file.read(self.read_size)
+        if not data:
+            # At EOF any held byte cannot complete a word, so drop it
+            # Prophesee files append a trailing newline that lands here
+            self._finished = True
+            self._pending_byte = b""
+            return None
+
+        if self._pending_byte:
+            data = self._pending_byte + data
+            self._pending_byte = b""
+
+        # A read can end mid word, hold the spare byte for the next read
+        usable_size = len(data) - (len(data) % _UINT16_SIZE)
+        if usable_size != len(data):
+            self._pending_byte = data[-1:]
+            data = data[:usable_size]
+
+        if not data:
+            return self._read_word_block()
+        return np.frombuffer(data, dtype="<u2")
+
+    def _decode_word_block(self, words: npt.NDArray[np.uint16]) -> _DecodedEventBlock:
+        # Classify every word by type, then collect the positions of each kind
+        word_types = (words >> 12).astype(np.uint16, copy=False)
+        payloads = (words & _PAYLOAD_MASK).astype(np.uint16, copy=False)
+        y_positions = np.flatnonzero(word_types == _EVT_ADDR_Y)
+        single_x_positions = np.flatnonzero(word_types == _EVT_ADDR_X)
+        base_positions = np.flatnonzero(word_types == _VECT_BASE_X)
+        vector_12_positions = np.flatnonzero(word_types == _VECT_12)
+        vector_8_positions = np.flatnonzero(word_types == _VECT_8)
+        low_positions = np.flatnonzero(word_types == _EVT_TIME_LOW)
+        high_positions = np.flatnonzero(word_types == _EVT_TIME_HIGH)
+
+        # Width each vector word spans in X (0 for nonvector words)
+        # The running cumulative sum tells each vector how far base-X has advanced
+        vector_sizes = np.zeros(len(words), dtype=np.int32)
+        vector_sizes[vector_12_positions] = 12
+        vector_sizes[vector_8_positions] = 8
+        cumulative_vector_sizes = np.empty(len(words) + 1, dtype=np.int64)
+        cumulative_vector_sizes[0] = 0
+        np.cumsum(vector_sizes, out=cumulative_vector_sizes[1:])
+
+        # Snapshot state at the block start, then advance it past this block so
+        # the next block decodes from the correct carried-over state.
+        self._update_state(
+            words,
+            payloads,
+            vector_sizes,
+            y_positions,
+            low_positions,
+            high_positions,
+            base_positions,
+        )
+
+        # How many CD events each word emits:
+        #    one per single-X word
+        #    one per set bit in a vector word
+        event_counts = np.zeros(len(words), dtype=np.uint8)
+        event_counts[single_x_positions] = 1
+        event_counts[vector_12_positions] = _VECTOR_12_COUNTS[payloads[vector_12_positions]]
+        vector_8_masks = words[vector_8_positions] & _VECTOR_8_MASK
+        event_counts[vector_8_positions] = _VECTOR_8_COUNTS[vector_8_masks]
+
+        event_count = int(event_counts.sum())
+        if event_count == 0:
+            return self._empty_event_block()
+
+        # Output slot where each word's events start
+        starts = np.empty(len(words), dtype=np.int64)
+        np.cumsum(event_counts, out=starts)
+        starts -= event_counts
+
+        # Allocate output columns,
+        # then compute the decoder state that applies to each EVT_ADDR_X or vector word that produces events
+        timestamps = np.empty(event_count, dtype=np.int64)
+        xs = np.empty(event_count, dtype=np.int32)
+        ys = np.empty(event_count, dtype=np.int32)
+        polarities = np.empty(event_count, dtype=np.bool_)
+        ends_word = np.empty(event_count, dtype=np.bool_)
+        event_word_positions = np.flatnonzero(event_counts > 0)
+        event_word_timestamps = self._timestamps_at_positions(
+            payloads,
+            event_word_positions,
+            low_positions,
+            high_positions,
+        )
+        y_values = (words[y_positions] & _ADDRESS_MASK).astype(np.int64, copy=False)
+        event_word_ys = self._int_state_from_updates(
+            y_positions,
+            y_values,
+            event_word_positions,
+            self._decode_initial_state.y,
+        )
+        event_word_types = word_types[event_word_positions]
+        is_single_x_event_word = event_word_types == _EVT_ADDR_X
+        is_vector_12_event_word = event_word_types == _VECT_12
+        is_vector_8_event_word = event_word_types == _VECT_8
+        is_vector_event_word = is_vector_12_event_word | is_vector_8_event_word
+        single_x_event_indexes = np.flatnonzero(is_single_x_event_word)
+        vector_12_event_indexes = np.flatnonzero(is_vector_12_event_word)
+        vector_8_event_indexes = np.flatnonzero(is_vector_8_event_word)
+        vector_event_indexes = np.flatnonzero(is_vector_event_word)
+        vector_event_positions = event_word_positions[vector_event_indexes]
+        vector_12_indexes_by_word = np.searchsorted(vector_event_indexes, vector_12_event_indexes)
+        vector_8_indexes_by_word = np.searchsorted(vector_event_indexes, vector_8_event_indexes)
+        base_polarities = (words[base_positions] & _POLARITY_BIT) != 0
+        vector_polarities = self._bool_state_at_positions(
+            base_positions,
+            base_polarities,
+            vector_event_positions,
+            self._decode_initial_state.vector_polarity,
+        )
+        vector_base_xs = self._vector_base_x_at_positions(
+            words,
+            base_positions,
+            vector_event_positions,
+            cumulative_vector_sizes,
+        )
+
+        self._fill_single_x_events(
+            words,
+            event_word_positions[single_x_event_indexes],
+            starts,
+            single_x_event_indexes,
+            event_word_timestamps,
+            event_word_ys,
+            timestamps,
+            xs,
+            ys,
+            polarities,
+            ends_word,
+        )
+        self._fill_vector_events(
+            words,
+            payloads,
+            event_word_positions[vector_12_event_indexes],
+            starts,
+            vector_12_event_indexes,
+            event_word_timestamps,
+            event_word_ys,
+            vector_12_indexes_by_word,
+            vector_polarities,
+            vector_base_xs,
+            timestamps,
+            xs,
+            ys,
+            polarities,
+            ends_word,
+            vector_size=12,
+        )
+        self._fill_vector_events(
+            words,
+            payloads,
+            event_word_positions[vector_8_event_indexes],
+            starts,
+            vector_8_event_indexes,
+            event_word_timestamps,
+            event_word_ys,
+            vector_8_indexes_by_word,
+            vector_polarities,
+            vector_base_xs,
+            timestamps,
+            xs,
+            ys,
+            polarities,
+            ends_word,
+            vector_size=8,
+        )
+        return _DecodedEventBlock(
+            t=timestamps.astype(np.float64, copy=False),
+            x=xs,
+            y=ys,
+            p=polarities,
+            ends_word=ends_word,
+        )
+
+    def _fill_single_x_events(
+        self,
+        words: npt.NDArray[np.uint16],
+        event_positions: npt.NDArray[np.int64],
+        starts: npt.NDArray[np.int64],
+        event_indexes: npt.NDArray[np.int64],
+        event_word_timestamps: npt.NDArray[np.int64],
+        event_word_ys: npt.NDArray[np.int64],
+        timestamps: npt.NDArray[np.int64],
+        xs: npt.NDArray[np.int32],
+        ys: npt.NDArray[np.int32],
+        polarities: npt.NDArray[np.bool_],
+        ends_word: npt.NDArray[np.bool_],
+    ) -> None:
+        if len(event_positions) == 0:
+            return
+
+        target_indices = starts[event_positions]
+        timestamps[target_indices] = event_word_timestamps[event_indexes]
+        event_words = words[event_positions]
+        xs[target_indices] = event_words & _ADDRESS_MASK
+        ys[target_indices] = event_word_ys[event_indexes]
+        polarities[target_indices] = (event_words & _POLARITY_BIT) != 0
+        ends_word[target_indices] = True
+
+    def _fill_vector_events(
+        self,
+        words: npt.NDArray[np.uint16],
+        payloads: npt.NDArray[np.uint16],
+        vector_positions: npt.NDArray[np.int64],
+        starts: npt.NDArray[np.int64],
+        event_indexes: npt.NDArray[np.int64],
+        event_word_timestamps: npt.NDArray[np.int64],
+        event_word_ys: npt.NDArray[np.int64],
+        vector_indexes_by_word: npt.NDArray[np.int64],
+        vector_polarities: npt.NDArray[np.bool_],
+        vector_base_xs: npt.NDArray[np.int32],
+        timestamps: npt.NDArray[np.int64],
+        xs: npt.NDArray[np.int32],
+        ys: npt.NDArray[np.int32],
+        polarities: npt.NDArray[np.bool_],
+        ends_word: npt.NDArray[np.bool_],
+        *,
+        vector_size: int,
+    ) -> None:
+        if len(vector_positions) == 0:
+            return
+
+        if vector_size == 12:
+            masks = payloads[vector_positions]
+            counts = _VECTOR_12_COUNTS[masks].astype(np.int64, copy=False)
+            offsets = _VECTOR_12_OFFSETS[masks]
+            vector_indexes = _VECTOR_12_INDEXES
+        else:
+            masks = (words[vector_positions] & _VECTOR_8_MASK).astype(np.uint16, copy=False)
+            counts = _VECTOR_8_COUNTS[masks].astype(np.int64, copy=False)
+            offsets = _VECTOR_8_OFFSETS[masks]
+            vector_indexes = _VECTOR_8_INDEXES
+
+        nonempty = counts > 0
+        if not np.any(nonempty):
+            return
+
+        vector_positions = vector_positions[nonempty]
+        counts = counts[nonempty]
+        offsets = offsets[nonempty]
+        event_indexes = event_indexes[nonempty]
+        vector_indexes_by_word = vector_indexes_by_word[nonempty]
+
+        has_event_at_offset = vector_indexes < counts[:, None]
+        vector_start_indices = starts[vector_positions, None]
+        target_indices = (vector_start_indices + vector_indexes)[has_event_at_offset]
+
+        timestamps[target_indices] = np.repeat(event_word_timestamps[event_indexes], counts)
+        ys[target_indices] = np.repeat(event_word_ys[event_indexes], counts)
+        polarities[target_indices] = np.repeat(
+            vector_polarities[vector_indexes_by_word],
+            counts,
+        )
+        base_xs = vector_base_xs[vector_indexes_by_word]
+        expanded_xs = base_xs[:, None] + offsets
+        xs[target_indices] = expanded_xs[has_event_at_offset]
+        ends_word[target_indices] = False
+        last_event_indices = starts[vector_positions] + counts - 1
+        ends_word[last_event_indices] = True
+
+    def _timestamps_at_positions(
+        self,
+        payloads: npt.NDArray[np.uint16],
+        event_positions: npt.NDArray[np.int64],
+        low_positions: npt.NDArray[np.int64],
+        high_positions: npt.NDArray[np.int64],
+    ) -> npt.NDArray[np.int64]:
+        low_values, _ = self._unwrapped_values(
+            payloads[low_positions],
+            initial_value=self._decode_initial_state.time_low,
+            initial_overflow=self._decode_initial_state.time_low_overflow,
+            wrap_increment=_TIME_LOW_RANGE,
+            shift=0,
+        )
+        high_values, _ = self._unwrapped_values(
+            payloads[high_positions],
+            initial_value=self._decode_initial_state.time_high,
+            initial_overflow=self._decode_initial_state.time_high_overflow,
+            wrap_increment=_TIME_HIGH_RANGE_US,
+            shift=12,
+        )
+        initial_low_timestamp = (
+            self._decode_initial_state.time_low_overflow + self._decode_initial_state.time_low
+        )
+        initial_high_timestamp = self._decode_initial_state.time_high_overflow + (
+            self._decode_initial_state.time_high << 12
+        )
+        low_at_events = self._int_state_from_updates(
+            low_positions,
+            low_values,
+            event_positions,
+            initial_low_timestamp,
+        )
+        high_at_events = self._int_state_from_updates(
+            high_positions,
+            high_values,
+            event_positions,
+            initial_high_timestamp,
+        )
+        np.add(low_at_events, high_at_events, out=low_at_events)
+        return low_at_events
+
+    @staticmethod
+    def _int_state_from_updates(
+        update_positions: npt.NDArray[np.int64],
+        update_values: npt.NDArray[np.int64],
+        event_positions: npt.NDArray[np.int64],
+        initial_value: int,
+    ) -> npt.NDArray[np.int64]:
+        if len(update_positions) == 0:
+            return np.full(len(event_positions), initial_value, dtype=np.int64)
+
+        # For each event, take the value from the most recent update at or before it;
+        # events before any update keep the carried in initial value
+        update_indexes = np.searchsorted(update_positions, event_positions, side="right") - 1
+        values = np.empty(len(event_positions), dtype=np.int64)
+        has_update = update_indexes >= 0
+        values[~has_update] = initial_value
+        values[has_update] = update_values[update_indexes[has_update]]
+        return values
+
+    @staticmethod
+    def _bool_state_at_positions(
+        update_positions: npt.NDArray[np.int64],
+        update_values: npt.NDArray[np.bool_],
+        event_positions: npt.NDArray[np.int64],
+        initial_value: bool,
+    ) -> npt.NDArray[np.bool_]:
+        if len(update_positions) == 0:
+            return np.full(len(event_positions), initial_value, dtype=np.bool_)
+
+        update_indexes = np.searchsorted(update_positions, event_positions, side="right") - 1
+        values = np.empty(len(event_positions), dtype=np.bool_)
+        has_update = update_indexes >= 0
+        values[~has_update] = initial_value
+        values[has_update] = update_values[update_indexes[has_update]]
+        return values
+
+    @staticmethod
+    def _unwrapped_values(
+        values: npt.NDArray[np.uint16],
+        *,
+        initial_value: int,
+        initial_overflow: int,
+        wrap_increment: int,
+        shift: int,
+    ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+        int_values = values.astype(np.int64, copy=False)
+        if len(int_values) == 0:
+            return np.empty((0,), dtype=np.int64), np.empty((0,), dtype=np.int64)
+
+        # The timer counts up then wraps to 0, so a value smaller than predecessor marks a wrap
+        # Accumulating wraps recovers the high bits
+        wraps = np.empty(len(int_values), dtype=np.bool_)
+        wraps[0] = int_values[0] < initial_value
+        current_values = int_values[1:]
+        previous_values = int_values[:-1]
+        wraps[1:] = current_values < previous_values
+        overflows = np.cumsum(wraps, dtype=np.int64)
+        overflows *= wrap_increment
+        overflows += initial_overflow
+        unwrapped = int_values << shift
+        unwrapped += overflows
+        return unwrapped, overflows
+
+    @staticmethod
+    def _last_overflow(
+        values: npt.NDArray[np.uint16],
+        *,
+        initial_value: int,
+        initial_overflow: int,
+        wrap_increment: int,
+    ) -> int:
+        int_values = values.astype(np.int64, copy=False)
+        wrap_count = int(int_values[0] < initial_value)
+        if len(int_values) > 1:
+            current_values = int_values[1:]
+            previous_values = int_values[:-1]
+            wrap_count += int(np.count_nonzero(current_values < previous_values))
+        return initial_overflow + (wrap_count * wrap_increment)
+
+    def _vector_base_x_at_positions(
+        self,
+        words: npt.NDArray[np.uint16],
+        base_positions: npt.NDArray[np.int64],
+        vector_positions: npt.NDArray[np.int64],
+        cumulative_sizes: npt.NDArray[np.int64],
+    ) -> npt.NDArray[np.int32]:
+        if len(base_positions) == 0:
+            carried_base_xs = self._decode_initial_state.base_x + cumulative_sizes[vector_positions]
+            return carried_base_xs.astype(np.int32, copy=False)
+
+        # base-X advances by the width of every vector word emitted since its base word,
+        # the gap between cumulative sizes gives the running base
+        base_indexes = np.searchsorted(base_positions, vector_positions, side="right") - 1
+        base_values = (words[base_positions] & _ADDRESS_MASK).astype(np.int64, copy=False)
+        base_xs = np.empty(len(vector_positions), dtype=np.int64)
+        has_base = base_indexes >= 0
+
+        positions_without_base = vector_positions[~has_base]
+        base_xs[~has_base] = (
+            self._decode_initial_state.base_x + cumulative_sizes[positions_without_base]
+        )
+
+        positions_with_base = vector_positions[has_base]
+        matching_base_indexes = base_indexes[has_base]
+        matching_base_positions = base_positions[matching_base_indexes]
+        vector_distance_from_base = (
+            cumulative_sizes[positions_with_base] - cumulative_sizes[matching_base_positions]
+        )
+        base_xs[has_base] = base_values[matching_base_indexes] + vector_distance_from_base
+        return base_xs.astype(np.int32, copy=False)
+
+    def _update_state(
+        self,
+        words: npt.NDArray[np.uint16],
+        payloads: npt.NDArray[np.uint16],
+        vector_sizes: npt.NDArray[np.int32],
+        y_positions: npt.NDArray[np.int64],
+        low_positions: npt.NDArray[np.int64],
+        high_positions: npt.NDArray[np.int64],
+        base_positions: npt.NDArray[np.int64],
+    ) -> None:
+        self._decode_initial_state = _Evt3State(
+            y=self.state.y,
+            base_x=self.state.base_x,
+            vector_polarity=self.state.vector_polarity,
+            time_high=self.state.time_high,
+            time_low=self.state.time_low,
+            time_high_overflow=self.state.time_high_overflow,
+            time_low_overflow=self.state.time_low_overflow,
+        )
+
+        if len(y_positions) > 0:
+            self.state.y = int(words[y_positions[-1]] & _ADDRESS_MASK)
+
+        if len(low_positions) > 0:
+            raw_lows = payloads[low_positions]
+            self.state.time_low = int(raw_lows[-1])
+            self.state.time_low_overflow = self._last_overflow(
+                raw_lows,
+                initial_value=self._decode_initial_state.time_low,
+                initial_overflow=self._decode_initial_state.time_low_overflow,
+                wrap_increment=_TIME_LOW_RANGE,
+            )
+
+        if len(high_positions) > 0:
+            raw_highs = payloads[high_positions]
+            self.state.time_high = int(raw_highs[-1])
+            self.state.time_high_overflow = self._last_overflow(
+                raw_highs,
+                initial_value=self._decode_initial_state.time_high,
+                initial_overflow=self._decode_initial_state.time_high_overflow,
+                wrap_increment=_TIME_HIGH_RANGE_US,
+            )
+
+        total_vector_size = int(vector_sizes.sum())
+        if len(base_positions) > 0:
+            last_base_position = int(base_positions[-1])
+            last_base_x = int(words[last_base_position] & _ADDRESS_MASK)
+            vector_width_after_last_base = int(vector_sizes[last_base_position + 1 :].sum())
+            self.state.base_x = last_base_x + vector_width_after_last_base
+            self.state.vector_polarity = bool(words[last_base_position] & _POLARITY_BIT)
+        else:
+            self.state.base_x += total_vector_size

--- a/src/evlib/codec/fileformat/evk.py
+++ b/src/evlib/codec/fileformat/evk.py
@@ -1,41 +1,46 @@
-"""evk file formats, mainly for Metavision SDK software by Prophesee.
-"""
+"""evk file formats, mainly for Metavision SDK software by Prophesee."""
+
 import logging
 from typing import Any
-from typing import Dict
 
-import numpy as np
-from expelliarmus import Wizard
+from ...types import RawEvents
+from ._evt3 import Evt3RawReader
+from ._iterator_access import IteratorAccess
 
 
 logger = logging.getLogger(__name__)
-
-from ...types import RawEvents
-from ._iterator_access import IteratorAccess
 
 
 # TODO make parser abstract and merge these classes.
 
 
 class IteratorEvk3(IteratorAccess):
+    """Iterator over Prophesee EVT3 RAW CD events."""
+
     FORMAT = "evk3"
 
     def __init__(self, evk3file: str) -> None:
+        """Create an iterator for an EVT3 RAW file.
+
+        Args:
+            evk3file: Path to the EVT3 RAW file.
+        """
         super().__init__(evk3file)
-        self.wizard = Wizard(encoding="evt3", fpath=self.file_name, chunk_size=16384)
+        self.reader = Evt3RawReader(self.file_name, chunk_size=16384)
         self.count = 0
 
-    def __next__(self) -> Dict[str, Any]:
-        chunk = next(self.wizard.read_chunk())
-        _l = len(chunk)
-        x = np.zeros((_l,), dtype=np.int32)
-        y = np.zeros((_l,), dtype=np.int32)
-        t = np.zeros((_l,), dtype=np.float64)
-        p = np.zeros((_l,), dtype=bool)
-        for _i, e in enumerate(chunk):
-            t[_i] = np.float64(e[0])
-            x[_i] = int(e[1])
-            y[_i] = int(e[2])
-            p[_i] = int(e[3])
-        self.count += _l
-        return RawEvents(x=x, y=y, timestamp=t, polarity=p)  # type: ignore
+    def __iter__(self) -> Any:
+        """Reset and return this iterator."""
+        self.count = 0
+        self.reader.reset()
+        return self
+
+    def close(self) -> None:
+        """Close the underlying EVT3 RAW reader."""
+        self.reader.close()
+
+    def __next__(self) -> RawEvents:
+        """Return the next decoded CD event chunk."""
+        chunk = self.reader.next_chunk()
+        self.count += len(chunk)
+        return RawEvents(x=chunk.x, y=chunk.y, timestamp=chunk.t, polarity=chunk.p)

--- a/tests/codec/fileformat/test_evk.py
+++ b/tests/codec/fileformat/test_evk.py
@@ -1,0 +1,127 @@
+"""EVK/EVT3 iterator tests."""
+
+import os
+import struct
+from typing import List
+from typing import Optional
+
+import numpy as np
+import pytest
+
+from evlib.codec import fileformat
+from evlib.codec.fileformat._evt3 import Evt3RawError
+from evlib.codec.fileformat._evt3 import Evt3RawReader
+
+
+def _write_evt3_raw(path: str, words: List[int], header: Optional[bytes] = None) -> None:
+    if header is None:
+        header = b"% evt 3.0\n% format EVT3;height=10;width=32\n% end\n"
+    with open(path, "wb") as file_handle:
+        file_handle.write(header)
+        for word in words:
+            file_handle.write(struct.pack("<H", word))
+
+
+def test_iterator_evk3_decodes_evt3_events(tmp_path):  # type: ignore
+    """Decode EVT3 single and vector CD events into RawEvents."""
+    path = os.path.join(tmp_path, "events.raw")
+    words = [
+        0x8001,  # time high = 1
+        0x6002,  # time low = 2
+        0x0003,  # y = 3
+        0x2804,  # x = 4, p = 1
+        0x300A,  # vector base x = 10, p = 0
+        0x4005,  # x = 10 and 12
+        0x5003,  # x = 22 and 23
+    ]
+    _write_evt3_raw(path, words)
+
+    events = next(fileformat.IteratorEvk3(path))
+
+    assert events.x.dtype.type is np.int32
+    assert events.y.dtype.type is np.int32
+    assert events.t.dtype.type is np.float64
+    assert events.p.dtype.type is np.bool_
+    assert events.x.tolist() == [4, 10, 12, 22, 23]
+    assert events.y.tolist() == [3, 3, 3, 3, 3]
+    assert events.t.tolist() == [4098.0, 4098.0, 4098.0, 4098.0, 4098.0]
+    assert events.p.tolist() == [True, False, False, False, False]
+
+
+def test_evt3_reader_preserves_complete_vector_when_chunk_limit_is_reached(tmp_path):  # type: ignore
+    """Keep vector events together when they cross the target chunk size."""
+    path = os.path.join(tmp_path, "events.raw")
+    words = [
+        0x8000,
+        0x6000,
+        0x0001,
+        0x2001,
+        0x300A,
+        0x400F,
+        0x201E,
+    ]
+    _write_evt3_raw(path, words)
+
+    reader = Evt3RawReader(path, chunk_size=2)
+    first_chunk = reader.next_chunk()
+    second_chunk = reader.next_chunk()
+
+    assert first_chunk.x.tolist() == [1, 10, 11, 12, 13]
+    assert second_chunk.x.tolist() == [30]
+
+
+def test_evt3_reader_tracks_time_low_and_high_wraps(tmp_path):  # type: ignore
+    """Reconstruct timestamps across EVT3 low and high timestamp wraps."""
+    path = os.path.join(tmp_path, "events.raw")
+    words = [
+        0x8FFF,
+        0x6FFF,
+        0x0001,
+        0x2001,
+        0x8000,
+        0x6000,
+        0x0001,
+        0x2002,
+    ]
+    _write_evt3_raw(path, words)
+
+    events = next(fileformat.IteratorEvk3(path))
+
+    assert events.t.tolist() == [16777215.0, 16781312.0]
+
+
+def test_evt3_reader_accepts_raw_without_header(tmp_path):  # type: ignore
+    """Decode headerless EVT3 words by treating the file as raw data."""
+    path = os.path.join(tmp_path, "events.raw")
+    _write_evt3_raw(path, [0x8000, 0x6001, 0x0002, 0x2803], header=b"")
+
+    events = next(fileformat.IteratorEvk3(path))
+
+    assert events.x.tolist() == [3]
+    assert events.y.tolist() == [2]
+    assert events.t.tolist() == [1.0]
+    assert events.p.tolist() == [True]
+
+
+def test_evt3_reader_ignores_odd_trailing_byte_at_eof(tmp_path):  # type: ignore
+    """Ignore a final byte that cannot form a complete EVT3 word."""
+    path = os.path.join(tmp_path, "events.raw")
+    _write_evt3_raw(path, [0x8000, 0x6001, 0x0002, 0x2803])
+    with open(path, "ab") as file_handle:
+        file_handle.write(b"\n")
+
+    events = next(fileformat.IteratorEvk3(path))
+
+    assert events.x.tolist() == [3]
+    assert events.y.tolist() == [2]
+    assert events.t.tolist() == [1.0]
+    assert events.p.tolist() == [True]
+
+
+def test_evt3_reader_rejects_non_evt3_raw_header(tmp_path):  # type: ignore
+    """Reject RAW files whose header declares a different event encoding."""
+    path = os.path.join(tmp_path, "events.raw")
+    _write_evt3_raw(path, [0x0000], header=b"% evt 2.0\n% format EVT2;height=10;width=32\n% end\n")
+
+    with pytest.raises(Evt3RawError, match="Only Prophesee EVT3 RAW"):
+        fileformat.IteratorEvk3(path)


### PR DESCRIPTION
Replace the Expelliarmus dependency used by `IteratorEvk3` with a Python/NumPy EVT3 RAW decoder. Keeps EVT3 support scoped to what is currently only needed by evlib for event loading. 

The new `Evt3RawReader` streams EVT3 RAW files in fixed size byte blocks, decodes little endian 16bit EVT3 words with NumPy, and yields `RawEvents` through `IteratorEvk3`.  It preserves EVT3 state across blocks and expands vector events with lookup tables.

Supports EVT3 words: 
  - `EVT_ADDR_Y`
  - `EVT_ADDR_X`
  - `VECT_BASE_X`
  - `VECT_12`
  - `VECT_8`
  - `EVT_TIME_LOW`
  - `EVT_TIME_HIGH`

#### Performance 
For raw EVT3 decoding alone, expelliarmus is still ~10x  faster (its in native C) 

However, for evlib's current `IteratorEvk3` usage, this implementation is ~10-17x faster as it avoids the previous per event Pytohn conversion loop from Expelliarmus events into `RawEvents` array. 

These benchmarks and numbers are derived from various tests on [Prophesee provided samples](https://docs.prophesee.ai/stable/datasets.html), specifically `laser.raw`, `pedestrians.raw`, and `driving_sample.raw`.