### PR TITLE
add ECD Dataset and tests

### DIFF
--- a/src/evlib/datasets/__init__.py
+++ b/src/evlib/datasets/__init__.py
@@ -4,6 +4,13 @@ from ._base import BlockAccessDataset
 from ._base import EventDataset
 from ._base import IteratorAccessDataset
 from ._base import event_sample_collate
+from .ecd import ECD_DAVIS240C_SENSOR_RESOLUTION
+from .ecd import ECD_REAL_SEQUENCES
+from .ecd import ECD_SEQUENCES
+from .ecd import ECD_SYNTHETIC_SEQUENCES
+from .ecd import ECDDataset
+from .ecd import ECDIterator
+from .ecd import ecd_collate_fn
 from .mvsec import MVSECDataset
 from .mvsec import MVSECIterator
 from .mvsec import mvsec_collate_fn
@@ -11,8 +18,15 @@ from .mvsec import mvsec_collate_fn
 
 __all__ = [
     "BlockAccessDataset",
+    "ECDDataset",
+    "ECDIterator",
+    "ECD_DAVIS240C_SENSOR_RESOLUTION",
+    "ECD_REAL_SEQUENCES",
+    "ECD_SEQUENCES",
+    "ECD_SYNTHETIC_SEQUENCES",
     "EventDataset",
     "IteratorAccessDataset",
+    "ecd_collate_fn",
     "event_sample_collate",
     "MVSECDataset",
     "MVSECIterator",

--- a/src/evlib/datasets/ecd.py
+++ b/src/evlib/datasets/ecd.py
@@ -1,0 +1,567 @@
+"""Event-Camera Dataset (ECD) wrappers.
+
+Expected text-file structure::
+    {root}/{sequence}/events.txt
+    {root}/{sequence}/images.txt
+    {root}/{sequence}/images/frame_00000000.png
+    {root}/{sequence}/imu.txt               (optional)
+    {root}/{sequence}/groundtruth.txt       (optional)
+    {root}/{sequence}/calib.txt             (optional)
+    {root}/{sequence}/depthmaps.txt         (synthetic sequences only, optional)
+
+This dataset wrapper delegates all DAVIS/RPG text recording I/O to
+class DavisRecordingLoader and adds the ECD sequence contract.
+
+Reference: https://rpg.ifi.uzh.ch/davis_data.html
+Mueggler, E., Rebecq, H., Gallego, G., Delbruck, T., & Scaramuzza, D. (2017).
+The Event-Camera Dataset and Simulator: Event-based Data for Pose Estimation,
+Visual Odometry, and SLAM. International Journal of Robotics Research, 36(2), 142-149.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from evlib.dataloaders import DavisCameraCalibration
+from evlib.dataloaders import DavisFrameSample
+from evlib.dataloaders import DavisImuData
+from evlib.dataloaders import DavisPoseData
+from evlib.dataloaders import DavisRecordingLoader
+from evlib.dataloaders import LoadingType
+from evlib.dataloaders import LoadMode
+from evlib.dataloaders import ResidentLoadMode
+from evlib.types import RawEvents
+
+from ._base import BlockAccessDataset
+from ._base import IteratorAccessDataset
+from ._base import event_sample_collate
+
+
+ECD_CAMERA_MODEL = "DAVIS240C"
+ECD_DAVIS240C_SENSOR_RESOLUTION: tuple[int, int] = (180, 240)
+
+ECD_REAL_SEQUENCES: tuple[str, ...] = (
+    "shapes_rotation",
+    "shapes_translation",
+    "shapes_6dof",
+    "poster_rotation",
+    "poster_translation",
+    "poster_6dof",
+    "boxes_rotation",
+    "boxes_translation",
+    "boxes_6dof",
+    "hdr_poster",
+    "hdr_boxes",
+    "outdoors_walking",
+    "outdoors_running",
+    "dynamic_rotation",
+    "dynamic_translation",
+    "dynamic_6dof",
+    "calibration",
+    "office_zigzag",
+    "office_spiral",
+    "urban",
+    "slider_close",
+    "slider_far",
+    "slider_hdr_close",
+    "slider_hdr_far",
+    "slider_depth",
+)
+ECD_SYNTHETIC_SEQUENCES: tuple[str, ...] = (
+    "simulation_3planes",
+    "simulation_3walls",
+)
+ECD_SEQUENCES: tuple[str, ...] = ECD_REAL_SEQUENCES + ECD_SYNTHETIC_SEQUENCES
+
+ecd_collate_fn = event_sample_collate
+
+
+def _validate_sequence_name(sequence: str) -> str:
+    if not sequence:
+        raise ValueError("ECD sequence name must not be empty.")
+
+    sequence_is_path = os.path.basename(sequence) != sequence
+    if sequence_is_path:
+        raise ValueError(f"ECD sequence must be a sequence name, not a path: {sequence!r}.")
+
+    if sequence not in ECD_SEQUENCES:
+        sequence_names = ", ".join(ECD_SEQUENCES)
+        raise ValueError(f"Unknown ECD sequence {sequence!r}. Expected one of: {sequence_names}.")
+
+    return sequence
+
+
+def _has_recording_file(sequence_dir: str) -> bool:
+    events_path = os.path.join(sequence_dir, "events.txt")
+    return os.path.isfile(events_path)
+
+
+def _has_nested_recording_file(sequence_dir: str) -> bool:
+    if not os.path.isdir(sequence_dir):
+        return False
+
+    for child_name in sorted(os.listdir(sequence_dir)):
+        child_dir = os.path.join(sequence_dir, child_name)
+        if not os.path.isdir(child_dir):
+            continue
+        if _has_recording_file(child_dir):
+            return True
+
+    return False
+
+
+def _sequence_is_extracted(root_path: str, sequence: str) -> bool:
+    sequence_dir = os.path.join(root_path, sequence)
+    return _has_recording_file(sequence_dir) or _has_nested_recording_file(sequence_dir)
+
+
+def _resolve_sequence_dir(root: str, sequence: str) -> str:
+    root_path = os.path.abspath(os.path.expanduser(root))
+    if not os.path.isdir(root_path):
+        raise FileNotFoundError(f"ECD dataset root does not exist: {root}")
+
+    root_is_sequence_dir = os.path.basename(root_path) == sequence
+    if root_is_sequence_dir and _has_recording_file(root_path):
+        return root_path
+
+    sequence_dir = os.path.join(root_path, sequence)
+    if os.path.isdir(sequence_dir):
+        return sequence_dir
+
+    zip_path = f"{sequence_dir}.zip"
+    if os.path.isfile(zip_path):
+        raise FileNotFoundError(
+            f"ECD sequence {sequence!r} is available only as {zip_path}. "
+            "Extract the text archive before constructing ECDDataset."
+        )
+
+    raise FileNotFoundError(
+        f"ECD sequence directory does not exist: {sequence_dir}. "
+        "Pass the dataset root that contains extracted sequence directories."
+    )
+
+
+class ECDDataset(BlockAccessDataset):
+    """Event-Camera Dataset (ECD) sequence.
+
+    The dataset is a wrapper around class DavisRecordingLoader.
+    It provides frame indexed samples while keeping low level event slicing and modality access
+    available through the ``loader`` property.
+
+    Indexing returns one sample dict per grayscale frame,
+    ``len(dataset)`` is the frame count,
+    and class ecd_collate_fn collates samples into batches.
+
+    Note:
+        Sample timestamps are in each recording's native clock and are not guaranteed to start at zero.
+        ECD sequences exported from rosbags carry absolute (Unix epoch) timestamps, for example ``boxes_6dof``,
+        others such as ``slider_depth`` start near zero.
+        All modalities within one recording share the same clock,
+        so time differences and time based queries are always consistent within a sequence.
+
+    Args:
+        root: Directory containing extracted ECD text file sequence directories.
+        sequence: Official ECD sequence name, for example ``"shapes_rotation"``.
+        load_imu: If True, load ``imu.txt`` when present.
+        load_gt_pose: If True, load ``groundtruth.txt`` when present.
+        event_load_mode: ``"lazy"`` uses read only event sidecars and ``"cached"`` loads event sidecars into memory.
+        image_load_mode: ``"lazy"`` decodes frames on demand and ``"cached"`` decodes all frames during initialization.
+        depth_load_mode: Load mode for optional synthetic ``depthmaps.txt`` files.
+        precompute_frame_event_indices: Whether to precompute frame-to-event index alignment at initialization.
+        By default this follows the DAVIS loader.
+        cache_dir: Optional root directory for DAVIS event sidecar caches.
+    """
+
+    CAMERA_MODEL = ECD_CAMERA_MODEL
+    SENSOR_RESOLUTION = ECD_DAVIS240C_SENSOR_RESOLUTION
+    SEQUENCES = ECD_SEQUENCES
+    REAL_SEQUENCES = ECD_REAL_SEQUENCES
+    SYNTHETIC_SEQUENCES = ECD_SYNTHETIC_SEQUENCES
+
+    def __init__(
+        self,
+        root: str,
+        sequence: str,
+        *,
+        load_imu: bool = True,
+        load_gt_pose: bool = True,
+        event_load_mode: ResidentLoadMode = "lazy",
+        image_load_mode: ResidentLoadMode = "lazy",
+        depth_load_mode: LoadMode = True,
+        precompute_frame_event_indices: bool | None = None,
+        cache_dir: str | None = None,
+    ) -> None:
+        """Initialize an ECD sequence dataset."""
+        self._root = os.path.abspath(os.path.expanduser(root))
+        self._sequence = _validate_sequence_name(sequence)
+        sequence_dir = _resolve_sequence_dir(root, self._sequence)
+        self._loader = DavisRecordingLoader(
+            sequence_dir,
+            load_imu=load_imu,
+            load_gt_pose=load_gt_pose,
+            event_load_mode=event_load_mode,
+            image_load_mode=image_load_mode,
+            depth_load_mode=depth_load_mode,
+            precompute_frame_event_indices=precompute_frame_event_indices,
+            cache_dir=cache_dir,
+            sensor_resolution=self.SENSOR_RESOLUTION,
+        )
+
+    @classmethod
+    def available_sequences(cls, root: str | None = None) -> tuple[str, ...]:
+        """Return official sequence names, optionally filtered by extracted files on disk."""
+        if root is None:
+            return cls.SEQUENCES
+
+        root_path = os.path.abspath(os.path.expanduser(root))
+        if not os.path.isdir(root_path):
+            raise FileNotFoundError(f"ECD dataset root does not exist: {root}")
+
+        extracted_sequences = [
+            sequence for sequence in cls.SEQUENCES if _sequence_is_extracted(root_path, sequence)
+        ]
+        return tuple(extracted_sequences)
+
+    @property
+    def loader(self) -> DavisRecordingLoader:
+        """Underlying DAVIS/RPG text recording loader."""
+        return self._loader
+
+    @property
+    def root(self) -> str:
+        """Dataset root passed to this wrapper."""
+        return self._root
+
+    @property
+    def sequence(self) -> str:
+        """Official ECD sequence name."""
+        return self._sequence
+
+    @property
+    def recording_dir(self) -> str:
+        """Resolved extracted recording directory used by the underlying loader."""
+        return self._loader.recording_dir
+
+    @property
+    def camera_model(self) -> str:
+        """Camera model for real ECD DAVIS sequences."""
+        return self.CAMERA_MODEL
+
+    @property
+    def sensor_resolution(self) -> tuple[int, int]:
+        """ECD DAVIS240C sensor resolution as ``(height, width)``."""
+        return self.SENSOR_RESOLUTION
+
+    def __getitem__(self, index: int) -> dict:
+        """Return a synchronized frame indexed sample.
+
+        The sample is a dict with keys:
+            ``events``,
+            ``timestamp``,
+            ``image``,
+            ``imu``,
+            ``pose``,
+            ``depth``
+        optional modalities are None when the sequence does not provide them.
+        ``timestamp`` is in the recording's native clock - see the class note on timestamps.
+        """
+        sample = self._loader.load_frame_sample(index)
+        return dict(sample)
+
+    def __len__(self) -> int:
+        """Number of grayscale frames in the sequence."""
+        return self.num_frames
+
+    def close(self) -> None:
+        """Release loader resources."""
+        self._loader.close()
+
+    def __repr__(self) -> str:
+        """Return a concise dataset representation."""
+        return f"{type(self).__name__}(root={self.root!r}, sequence={self.sequence!r})"
+
+    # Events
+
+    def load_events(self, start_index: int, end_index: int) -> RawEvents:
+        """Load events in ``[start_index, end_index)``."""
+        return self._loader.load_events(start_index, end_index)
+
+    @property
+    def num_events(self) -> int:
+        """Total number of events."""
+        return self._loader.num_events
+
+    def time_to_index(self, t: float) -> int:
+        """Find the last event strictly before time ``t``."""
+        return self._loader.time_to_index(t)
+
+    def index_to_time(self, index: int) -> float:
+        """Return the timestamp of one event by index."""
+        return self._loader.index_to_time(index)
+
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        """Vectorized form of :meth:`time_to_index`."""
+        return self._loader.times_to_indices(timestamps)
+
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        """Vectorized form of :meth:`index_to_time`."""
+        return self._loader.indices_to_times(indices)
+
+    def get_events_by_time(self, t_start: float, t_end: float) -> RawEvents:
+        """Load events in ``[t_start, t_end)``."""
+        return self._loader.get_events_by_time(t_start, t_end)
+
+    def iter_events(
+        self,
+        num_events: int | None = None,
+        time_window: float | None = None,
+    ) -> Iterator[RawEvents]:
+        """Yield event chunks by count or by time window."""
+        return self._loader.iter_events(num_events=num_events, time_window=time_window)
+
+    @property
+    def t_start(self) -> float | None:
+        """Timestamp of the first event, or None for empty recordings."""
+        return self._loader.t_start
+
+    @property
+    def t_end(self) -> float | None:
+        """Timestamp of the last event, or None for empty recordings."""
+        return self._loader.t_end
+
+    @property
+    def duration(self) -> float | None:
+        """Event timestamp span in seconds, or None for empty recordings."""
+        return self._loader.duration
+
+    @property
+    def event_load_mode(self) -> LoadingType:
+        """Configured event loading mode."""
+        return self._loader.event_load_mode
+
+    @property
+    def cache_dir(self) -> str:
+        """Root directory for DAVIS event sidecar caches."""
+        return self._loader.cache_dir
+
+    # Frames / images
+
+    @property
+    def has_images(self) -> bool:
+        """Whether image timestamps and frame references are available."""
+        return self._loader.has_images
+
+    @property
+    def frame_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Frame timestamps from ``images.txt``, or None if unavailable."""
+        return self._loader.frame_timestamps
+
+    @property
+    def frame_event_indices(self) -> npt.NDArray[np.int64] | None:
+        """First event index at or after each frame timestamp, if precomputed."""
+        return self._loader.frame_event_indices
+
+    @property
+    def image_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Alias for ``frame_timestamps``."""
+        return self._loader.image_timestamps
+
+    @property
+    def image_shape(self) -> tuple[int, int] | None:
+        """Decoded frame shape as ``(height, width)``, if frames are available."""
+        return self._loader.image_shape
+
+    @property
+    def num_frames(self) -> int:
+        """Number of referenced grayscale frames."""
+        return self._loader.num_frames
+
+    @property
+    def num_images(self) -> int:
+        """Alias of ``num_frames``."""
+        return self._loader.num_images
+
+    @property
+    def image_load_mode(self) -> LoadingType:
+        """Configured image loading mode."""
+        return self._loader.image_load_mode
+
+    def find_nearest_frame_index(self, t: float) -> int:
+        """Return the frame index nearest to ``t``."""
+        return self._loader.find_nearest_frame_index(t)
+
+    def find_nearest_image_index(self, t: float) -> int:
+        """Alias of :meth:`find_nearest_frame_index`."""
+        return self._loader.find_nearest_image_index(t)
+
+    def load_image(self, frame_index: int) -> npt.NDArray[np.uint8] | None:
+        """Load one grayscale frame by index."""
+        return self._loader.load_image(frame_index)
+
+    def load_frame_sample(self, frame_index: int) -> DavisFrameSample:
+        """Load events and optional modalities associated with one frame."""
+        return self._loader.load_frame_sample(frame_index)
+
+    # Calibration / undistortion
+
+    @property
+    def has_calibration(self) -> bool:
+        """Whether ``calib.txt`` is available."""
+        return self._loader.calibration is not None
+
+    @property
+    def calibration(self) -> DavisCameraCalibration | None:
+        """Parsed OpenCV pinhole calibration, if available."""
+        return self._loader.calibration
+
+    def undistort_events(self, events: RawEvents) -> RawEvents:
+        """Apply DAVIS calibration to event coordinates."""
+        return self._loader.undistort_events(events)
+
+    def undistort_image(self, image: npt.NDArray[np.uint8]) -> npt.NDArray[np.uint8]:
+        """Apply DAVIS calibration to one grayscale frame."""
+        return self._loader.undistort_image(image)
+
+    # IMU
+
+    @property
+    def has_imu(self) -> bool:
+        """Whether IMU data were requested and loaded."""
+        return self._loader.has_imu
+
+    @property
+    def imu_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """IMU timestamps, or None if IMU is unavailable."""
+        return self._loader.imu_timestamps
+
+    @property
+    def imu_data(self) -> DavisImuData | None:
+        """Loaded IMU arrays, or None if IMU is unavailable."""
+        return self._loader.imu_data
+
+    def load_imu(self, t_start: float, t_end: float) -> DavisImuData | None:
+        """Return IMU samples in ``[t_start, t_end)``."""
+        return self._loader.load_imu(t_start, t_end)
+
+    # Ground-truth pose
+
+    @property
+    def has_gt_pose(self) -> bool:
+        """Whether ground truth pose data were requested and loaded."""
+        return self._loader.has_gt_pose
+
+    @property
+    def gt_pose(self) -> DavisPoseData | None:
+        """Loaded ground truth pose trajectory, or None if unavailable."""
+        return self._loader.gt_pose
+
+    @property
+    def gt_pose_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Ground truth pose timestamps, or None if unavailable."""
+        return self._loader.gt_pose_timestamps
+
+    def load_nearest_pose(self, t: float) -> npt.NDArray[np.float64] | None:
+        """Return nearest raw pose row ``[px, py, pz, qx, qy, qz, qw]``."""
+        return self._loader.load_nearest_pose(t)
+
+    # Depth maps
+
+    @property
+    def has_depth(self) -> bool:
+        """Whether optional ``depthmaps.txt`` is available."""
+        return self._loader.has_depth
+
+    @property
+    def depth_load_mode(self) -> LoadingType:
+        """Configured depth map loading mode."""
+        return self._loader.depth_load_mode
+
+    @property
+    def depth_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Depth map timestamps, or None if unavailable."""
+        return self._loader.depth_timestamps
+
+    @property
+    def num_depth_maps(self) -> int:
+        """Number of referenced depth maps."""
+        return self._loader.num_depth_maps
+
+    def find_nearest_depth_index(self, t: float) -> int:
+        """Return the depth map index nearest to ``t``."""
+        return self._loader.find_nearest_depth_index(t)
+
+    def load_depth(self, depth_index: int) -> npt.NDArray[np.float32] | None:
+        """Load one depth map by index if depth maps are available."""
+        return self._loader.load_depth(depth_index)
+
+
+class ECDIterator(IteratorAccessDataset):
+    """Streaming iterator over an ECD sequence.
+
+    Yields the same dicts as :meth:`ECDDataset.__getitem__`, frame by frame.
+
+    Args:
+        root: Directory containing extracted ECD text file sequence directories.
+        sequence: Official ECD sequence name.
+        ``**kwargs``: Forwarded to class ECDDataset.
+    """
+
+    def __init__(self, root: str, sequence: str, **kwargs: Any) -> None:
+        """Initialize an iterator over one ECD sequence."""
+        self._dataset = ECDDataset(root, sequence, **kwargs)
+        self._current = 0
+
+    @property
+    def dataset(self) -> ECDDataset:
+        """Underlying map style ECD dataset."""
+        return self._dataset
+
+    @property
+    def root(self) -> str:
+        """Dataset root passed to the wrapped dataset."""
+        return self._dataset.root
+
+    @property
+    def sequence(self) -> str:
+        """Official ECD sequence name."""
+        return self._dataset.sequence
+
+    @property
+    def camera_model(self) -> str:
+        """Camera model for real ECD DAVIS sequences."""
+        return self._dataset.camera_model
+
+    def __iter__(self) -> ECDIterator:
+        """Return the iterator reset to the first frame."""
+        self._current = 0
+        return self
+
+    def __next__(self) -> dict:
+        """Return the next frame indexed sample."""
+        dataset_length = len(self._dataset)
+        if self._current >= dataset_length:
+            raise StopIteration
+
+        current_index = self._current
+        sample = self._dataset[current_index]
+        self._current += 1
+        return sample
+
+    def reset(self) -> None:
+        """Reset iteration cursor to the beginning."""
+        self._current = 0
+
+    def close(self) -> None:
+        """Release wrapped dataset resources."""
+        self._dataset.close()
+
+    def __repr__(self) -> str:
+        """Return a concise iterator representation."""
+        return f"{type(self).__name__}(root={self.root!r}, sequence={self.sequence!r})"

--- a/tests/datasets/test_ecd.py
+++ b/tests/datasets/test_ecd.py
@@ -1,0 +1,373 @@
+"""Tests for ECDDataset using synthetic ECD format sequences."""
+
+# mypy: disable-error-code=no-untyped-def
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from PIL import Image
+
+from evlib.dataloaders import DavisRecordingLoader
+from evlib.datasets import ECD_DAVIS240C_SENSOR_RESOLUTION
+from evlib.datasets import ECD_SEQUENCES
+from evlib.datasets import ECDDataset
+from evlib.datasets import ECDIterator
+from evlib.datasets import ecd_collate_fn
+from evlib.datasets import event_sample_collate
+from evlib.types import RawEvents
+
+
+HEIGHT, WIDTH = ECD_DAVIS240C_SENSOR_RESOLUTION
+
+
+def _write_png(path: Path, value: int) -> npt.NDArray[np.uint8]:
+    image_values = np.arange(HEIGHT * WIDTH, dtype=np.uint16)
+    image = ((image_values.reshape(HEIGHT, WIDTH) + value) % 256).astype(np.uint8)
+    Image.fromarray(image).save(path)
+    return image
+
+
+def _write_depth_png(path: Path, value: int) -> npt.NDArray[np.float32]:
+    depth = np.full((HEIGHT, WIDTH), value, dtype=np.uint16)
+    Image.fromarray(depth).save(path)
+    return depth.astype(np.float32)
+
+
+def _write_recording(
+    recording_dir: Path,
+    *,
+    with_imu: bool = True,
+    with_pose: bool = True,
+    with_depth: bool = False,
+) -> None:
+    recording_dir.mkdir(parents=True, exist_ok=True)
+    image_dir = recording_dir / "images"
+    image_dir.mkdir()
+
+    _write_png(image_dir / "frame_00000000.png", 0)
+    _write_png(image_dir / "frame_00000001.png", 10)
+    _write_png(image_dir / "frame_00000002.png", 20)
+
+    (recording_dir / "events.txt").write_text(
+        "\n".join(
+            [
+                "0.000000 1 0 1",
+                "0.050000 2 1 0",
+                "0.100000 3 2 1",
+                "0.150000 4 3 -1",
+                "0.200000 5 4 1",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (recording_dir / "images.txt").write_text(
+        "\n".join(
+            [
+                "0.000000 images/frame_00000000.png",
+                "0.100000 images/frame_00000001.png",
+                "0.200000 images/frame_00000002.png",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (recording_dir / "calib.txt").write_text(
+        "120.0 121.0 120.0 90.0 -0.1 0.2 0.01 0.02 0.0\n",
+        encoding="utf-8",
+    )
+
+    if with_imu:
+        (recording_dir / "imu.txt").write_text(
+            "\n".join(
+                [
+                    "0.025000 1.0 2.0 3.0 0.1 0.2 0.3",
+                    "0.075000 4.0 5.0 6.0 0.4 0.5 0.6",
+                    "0.125000 7.0 8.0 9.0 0.7 0.8 0.9",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if with_pose:
+        (recording_dir / "groundtruth.txt").write_text(
+            "\n".join(
+                [
+                    "0.000000 1.0 2.0 3.0 0.0 0.0 0.0 1.0",
+                    "0.100000 4.0 5.0 6.0 0.0 0.0 1.0 0.0",
+                    "0.200000 7.0 8.0 9.0 0.0 1.0 0.0 0.0",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if with_depth:
+        depth_dir = recording_dir / "depthmaps"
+        depth_dir.mkdir()
+        _write_depth_png(depth_dir / "frame_00000000.png", 100)
+        _write_depth_png(depth_dir / "frame_00000001.png", 200)
+        (recording_dir / "depthmaps.txt").write_text(
+            "\n".join(
+                [
+                    "0.000000 depthmaps/frame_00000000.png",
+                    "0.100000 depthmaps/frame_00000001.png",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+
+def _write_sequence(root: Path, sequence: str, **kwargs) -> Path:
+    recording_dir = root / sequence
+    _write_recording(recording_dir, **kwargs)
+    return recording_dir
+
+
+def _write_nested_sequence(root: Path, sequence: str, **kwargs) -> Path:
+    recording_dir = root / sequence / sequence
+    _write_recording(recording_dir, **kwargs)
+    return recording_dir
+
+
+def _cache_dir(root: Path) -> str:
+    return str(root / ".cache")
+
+
+@pytest.fixture()
+def ecd_root(tmp_path: Path) -> Path:
+    """Synthetic ECD root with one extracted sequence."""
+    _write_sequence(tmp_path, "shapes_rotation")
+    return tmp_path
+
+
+class TestECDDataset:
+    """ECD map style dataset behavior."""
+
+    def test_sequence_sample_uses_davis_loader_and_loads_default_modalities(
+        self,
+        ecd_root: Path,
+    ) -> None:
+        """A sample carries events, frame, IMU, and pose by default."""
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as ds:
+            sample = ds[1]
+
+            assert isinstance(ds.loader, DavisRecordingLoader)
+            assert ds.sequence == "shapes_rotation"
+            assert ds.camera_model == "DAVIS240C"
+            assert ds.sensor_resolution == (HEIGHT, WIDTH)
+            assert len(ds) == 3
+            assert ds.num_events == 5
+            assert sample["timestamp"] == pytest.approx(0.1)
+            assert sample["image"] is not None
+            assert sample["image"].shape == (HEIGHT, WIDTH)
+            assert sample["imu"] is not None
+            assert sample["imu"]["timestamp"].tolist() == [0.025, 0.075]
+            assert sample["pose"] is not None
+            np.testing.assert_array_equal(sample["pose"][:3], np.array([4.0, 5.0, 6.0]))
+
+    def test_negative_index_returns_last_frame(self, ecd_root: Path) -> None:
+        """ds[-1] is the last frame."""
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as ds:
+            assert ds[-1]["timestamp"] == ds[len(ds) - 1]["timestamp"]
+
+    def test_index_out_of_range_raises(self, ecd_root: Path) -> None:
+        """An index past the last frame raises IndexError."""
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as ds:
+            with pytest.raises(IndexError):
+                ds[len(ds)]
+
+    def test_event_time_and_index_helpers_delegate_to_loader(self, ecd_root: Path) -> None:
+        """Time and index lookups return the loader's event results."""
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as ds:
+            events = ds.get_events_by_time(0.05, 0.16)
+            indices = ds.times_to_indices(np.array([0.0, 0.101, 0.3]))
+            times = ds.indices_to_times(np.array([0, 2, 4]))
+
+        np.testing.assert_array_equal(events.x, np.array([2, 3, 4], dtype=np.int16))
+        np.testing.assert_array_equal(indices, np.array([-1, 2, 4], dtype=np.int64))
+        np.testing.assert_array_equal(times, np.array([0.0, 0.1, 0.2]))
+
+    def test_nested_extracted_archive_layout(self, tmp_path: Path) -> None:
+        """A sequence nested one directory deep still resolves."""
+        recording_dir = _write_nested_sequence(tmp_path, "boxes_6dof")
+
+        with ECDDataset(str(tmp_path), "boxes_6dof", cache_dir=_cache_dir(tmp_path)) as ds:
+            assert ds.recording_dir == str(recording_dir)
+            assert ds.num_frames == 3
+            assert ds.load_image(0) is not None
+
+    def test_missing_optional_modalities_return_none(self, tmp_path: Path) -> None:
+        """A sequence without imu.txt loads, and the imu field is None."""
+        _write_sequence(tmp_path, "slider_depth", with_imu=False, with_pose=True)
+
+        with ECDDataset(str(tmp_path), "slider_depth", cache_dir=_cache_dir(tmp_path)) as ds:
+            sample = ds[1]
+
+            assert not ds.has_imu
+            assert ds.has_gt_pose
+            assert sample["imu"] is None
+            assert sample["pose"] is not None
+
+    def test_synthetic_sequence_depthmaps_are_exposed(self, tmp_path: Path) -> None:
+        """Synthetic sequence depth maps reach the sample dict."""
+        _write_sequence(
+            tmp_path,
+            "simulation_3planes",
+            with_imu=False,
+            with_pose=True,
+            with_depth=True,
+        )
+
+        with ECDDataset(str(tmp_path), "simulation_3planes", cache_dir=_cache_dir(tmp_path)) as ds:
+            sample = ds[1]
+            depth = ds.load_depth(0)
+
+            assert ds.has_depth
+            assert ds.num_depth_maps == 2
+            assert sample["depth"] is not None
+            assert sample["depth"].shape == (HEIGHT, WIDTH)
+            assert depth is not None
+            assert depth.dtype == np.float32
+
+    def test_available_sequences_reports_extracted_sequences_only(self, tmp_path: Path) -> None:
+        """Discovery lists extracted sequences and skips zip only ones."""
+        _write_sequence(tmp_path, "shapes_rotation")
+        _write_nested_sequence(tmp_path, "boxes_6dof")
+        (tmp_path / "slider_depth.zip").write_bytes(b"not a real zip")
+
+        available = ECDDataset.available_sequences(str(tmp_path))
+
+        assert available == ("shapes_rotation", "boxes_6dof")
+        assert ECDDataset.available_sequences() == ECD_SEQUENCES
+
+    def test_unknown_sequence_and_path_like_sequence_raise(self, tmp_path: Path) -> None:
+        """Unknown names and path like input are rejected."""
+        with pytest.raises(ValueError, match="Unknown ECD sequence"):
+            ECDDataset(str(tmp_path), "not_a_sequence")
+
+        with pytest.raises(ValueError, match="not a path"):
+            ECDDataset(str(tmp_path), "../shapes_rotation")
+
+    def test_zip_only_sequence_has_actionable_error(self, tmp_path: Path) -> None:
+        """A zip only sequence tells the user to extract it first."""
+        (tmp_path / "slider_depth.zip").write_bytes(b"not a real zip")
+
+        with pytest.raises(FileNotFoundError, match="Extract the text archive"):
+            ECDDataset(str(tmp_path), "slider_depth")
+
+    def test_undistort_events_applies_calibration(self, ecd_root: Path) -> None:
+        """Calibration is parsed and undistortion moves event coordinates."""
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as ds:
+            events = ds.load_events(0, ds.num_events)
+            undistorted = ds.undistort_events(events)
+
+            assert ds.has_calibration
+            assert len(undistorted) == len(events)
+            moved = not np.array_equal(undistorted.x, events.x) or not np.array_equal(
+                undistorted.y, events.y
+            )
+            assert moved
+
+    def test_lazy_and_cached_modes_return_same_sample(self, ecd_root: Path) -> None:
+        """Cached loading yields the same sample as the lazy default."""
+        cache = _cache_dir(ecd_root)
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=cache) as lazy_ds:
+            lazy = lazy_ds[1]
+        with ECDDataset(
+            str(ecd_root),
+            "shapes_rotation",
+            event_load_mode="cached",
+            image_load_mode="cached",
+            cache_dir=cache,
+        ) as cached_ds:
+            cached = cached_ds[1]
+
+        assert cached["timestamp"] == lazy["timestamp"]
+        np.testing.assert_array_equal(cached["image"], lazy["image"])
+        np.testing.assert_array_equal(cached["events"].x, lazy["events"].x)
+
+    def test_repr_includes_root_and_sequence(self, ecd_root: Path) -> None:
+        """Repr shows the root and sequence name."""
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as ds:
+            text = repr(ds)
+
+        assert "ECDDataset" in text
+        assert str(ecd_root) in text
+        assert "shapes_rotation" in text
+
+
+class TestECDIterator:
+    """ECD iterator behavior."""
+
+    def test_iterator_reset_replays_sequence(self, ecd_root: Path) -> None:
+        """Reset rewinds the iterator for a second pass."""
+        with ECDIterator(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as it:
+            first_pass = list(it)
+            it.reset()
+            second_pass = list(it)
+
+        assert len(first_pass) == 3
+        assert len(second_pass) == 3
+        assert first_pass[0]["timestamp"] == second_pass[0]["timestamp"]
+
+    def test_iterator_stop(self, ecd_root: Path) -> None:
+        """Next raises StopIteration past the last frame."""
+        with ECDIterator(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as it:
+            for _ in it:
+                pass
+
+            with pytest.raises(StopIteration):
+                next(it)
+
+
+class TestECDCollate:
+    """ECD collate helper behavior."""
+
+    def test_collate_aliases_generic_helper(self) -> None:
+        """ecd_collate_fn is the shared event sample collate."""
+        assert ecd_collate_fn is event_sample_collate
+
+    def test_collate_preserves_variable_length_events(self, ecd_root: Path) -> None:
+        """Collate keeps variable-length event windows as a list."""
+        with ECDDataset(str(ecd_root), "shapes_rotation", cache_dir=_cache_dir(ecd_root)) as ds:
+            batch = ecd_collate_fn([ds[0], ds[1]])
+
+        assert isinstance(batch["timestamp"], np.ndarray)
+        assert batch["timestamp"].shape == (2,)
+        assert isinstance(batch["events"], list)
+        assert [len(events) for events in batch["events"]] == [0, 2]
+        assert all(isinstance(events, RawEvents) for events in batch["events"])
+        assert isinstance(batch["image"], list)
+        assert isinstance(batch["imu"], list)
+        assert isinstance(batch["pose"], list)
+
+
+def test_real_ecd_slider_depth(tmp_path: Path) -> None:
+    """Opt in check against a local extracted ECD copy."""
+    ecd_root = os.environ.get("EVLIB_ECD_ROOT")
+    if ecd_root is None:
+        pytest.skip("Set EVLIB_ECD_ROOT to an extracted ECD text-file dataset root.")
+
+    with ECDDataset(ecd_root, "slider_depth", cache_dir=_cache_dir(tmp_path)) as ds:
+        first_event_count = min(128, ds.num_events)
+        first_events = ds.load_events(0, first_event_count)
+        sample = ds[0]
+
+        assert ds.sequence == "slider_depth"
+        assert ds.camera_model == "DAVIS240C"
+        assert ds.sensor_resolution == (HEIGHT, WIDTH)
+        assert ds.num_events > 0
+        assert len(ds) > 0
+        assert len(first_events) == first_event_count
+        assert sample["image"] is not None
+        assert sample["image"].shape == (HEIGHT, WIDTH)
+        assert sample["imu"] is None
+        assert sample["pose"] is not None


### PR DESCRIPTION
Adds `ECDDataset` and `ECDIterator`

  - `ECDDataset` - map style dataset (`__getitem__`/`__len__`). One sample per grayscale frame. Each sample bundles events, the frame, and available aligned modalities like pose, depth, and IMU. Wraps `DavisRecordingLoader`.
  - `ECDIterator` - iterable variant for streaming.
  - `ecd_collate_fn` - pytorch collate alias for `event_sample_collate`. Variable length event packets while stacking timestamps.
  - `test_ecd.py` runs against built synthetic recording. Covers the sample/modality contract, optional modalities, synthetic depth, invalid range indexing, undistortion, etc...

#### Notes
- Events and images lazy load by default. Cached loading is available. Depth maps have a separate load mode.
- Set sequence constants  (`ECD_SEQUENCES`, `ECD_REAL_SEQUENCES`, `ECD_SYNTHETIC_SEQUENCES`) and `ECD_DAVIS240C_SENSOR_RESOLUTION`
- Some sequences have nested empty directories when extracting (e.g. `davis/boxes_6dof/boxes_6dof/`). This is handled. Also points users to extract zip only sequences.