### PR TITLE
Fix RawEvents append and slicing contract

### DIFF
--- a/examples/read_aedat4.py
+++ b/examples/read_aedat4.py
@@ -6,7 +6,7 @@ from evlib.codec import fileformat
 aedat4_file_path = "./artifacts/sample_data/sample.aedat4"
 
 # Events
-# Each batch is a RawEvents with arrays [x, y, t, p]
+# Each batch is a RawEvents object. RawEvents.as_numpy() returns [y, x, t, p].
 event_iterator = fileformat.IteratorAedat4Event(aedat4_file_path)
 num_events = 0
 for events in event_iterator:

--- a/src/evlib/types/raw_events.py
+++ b/src/evlib/types/raw_events.py
@@ -1,7 +1,9 @@
 """Data type for multiple events."""
-import copy
+
 from dataclasses import dataclass
-from typing import Any, List, Optional, Union
+from typing import Any
+from typing import Union
+from typing import overload
 
 import numpy as np
 import numpy.typing as npt
@@ -11,38 +13,69 @@ from .raw_event import RawEvent
 
 @dataclass
 class RawEvents:
-    """Dataclass for a batch of raw events."""
+    """Dataclass for a batch of raw events.
+
+    Dense rows returned by integer indexing and :meth:`as_numpy` follow
+    the ``[y, x, t, p]`` convention.
+    """
+
     x: Union[npt.NDArray[np.int16], npt.NDArray[np.int32]]  # [0, width]
     y: Union[npt.NDArray[np.int16], npt.NDArray[np.int32]]  # [0, height]
     timestamp: npt.NDArray[np.float64]
-    polarity: npt.NDArray[np.bool_]   # true for positive, false for negative
+    polarity: npt.NDArray[np.bool_]  # true for positive, false for negative
 
     # Shortcuts
     @property
     def p(self) -> npt.NDArray[np.bool_]:
-        """Alias for polatiry.
-        """
+        """Alias for polarity."""
         return self.polarity
 
     @property
     def t(self) -> npt.NDArray[np.float64]:
-        """Alias for timestamp.
-        """
+        """Alias for timestamp."""
         return self.timestamp
 
     # Build-ins
-    def __getitem__(self, index: Union[int, str]) -> npt.NDArray[np.float64]:
-        """Get an event as numpy array.
+    @overload
+    def __getitem__(self, index: int) -> npt.NDArray[np.float64]:  # noqa: D105
+        ...
+
+    @overload
+    def __getitem__(self, index: slice) -> "RawEvents":  # noqa: D105
+        ...
+
+    @overload
+    def __getitem__(self, index: str) -> Any:  # noqa: D105
+        ...
+
+    def __getitem__(
+        self, index: Union[int, slice, str]
+    ) -> Union[Any, "RawEvents", npt.NDArray[np.float64]]:
+        """Get an event, event slice, or named column.
+
+        Integer indexes return dense ``[y, x, t, p]`` rows, while slice indexes
+        return a ``RawEvents`` batch.
 
         Args:
-            index (int): index in the batch
+            index: Integer index, slice, or column name.
 
         Returns:
-            npt.NDArray[np.float64]: 1-d numpy array.
+            The selected event, event batch, or named column.
         """
         if isinstance(index, str):
-            return getattr(self, index)  # type: ignore
-        return np.array([self.y[index], self.x[index], self.t[index], self.p[index]], dtype=np.float64)
+            return getattr(self, index)
+        if isinstance(index, slice):
+            return RawEvents(
+                x=self.x[index],
+                y=self.y[index],
+                timestamp=self.timestamp[index],
+                polarity=self.polarity[index],
+            )
+        event = np.array(
+            [self.y[index], self.x[index], self.t[index], self.p[index]],
+            dtype=np.float64,
+        )
+        return event
 
     def __len__(self) -> int:
         """Get the number of events.
@@ -54,8 +87,7 @@ class RawEvents:
 
     @property
     def n(self) -> int:
-        """Alias for len().
-        """
+        """Return the event count."""
         return len(self)
 
     # Utility
@@ -68,12 +100,15 @@ class RawEvents:
         self.x = np.append(self.x, e.x)
         self.y = np.append(self.y, e.y)
         self.timestamp = np.append(self.timestamp, e.timestamp)
-        self.polarity = np.append(self.x, e.x)
+        self.polarity = np.append(self.polarity, e.polarity)
 
     def as_numpy(self) -> npt.NDArray[np.float64]:
         """Convert event object into 2-d numpy array.
 
+        Rows follow the ``[y, x, t, p]`` convention.
+
         Returns:
             npt.NDArray[np.float64]: 2-d numpy array, [n_events, 4].
         """
-        return np.stack([self.y, self.x, self.t, self.p]).astype(np.float64).T
+        events = np.column_stack((self.y, self.x, self.t, self.p))
+        return events.astype(np.float64)

--- a/tests/types/test_raw_events.py
+++ b/tests/types/test_raw_events.py
@@ -1,16 +1,59 @@
-
-
-import os
+# noqa: D100
 import numpy as np
 
 from evlib import types
 from evlib.utils import basics as basic_utils
 
-def test_raw_events_properties():    # type: ignore
+
+def test_raw_events_properties():  # type: ignore  # noqa: D103
     ne = 20
     height, width = 20, 40
     ev = basic_utils.generate_events(ne, height, width, 0.1, 0.24)
-    e = types.RawEvents(y=ev[:, 0], x=ev[:, 1], timestamp=ev[:, 2], polarity=ev[:, 3])
+    e = types.RawEvents(
+        y=ev[:, 0],
+        x=ev[:, 1],
+        timestamp=ev[:, 2],
+        polarity=ev[:, 3],
+    )
     assert len(e) == ne
     np.testing.assert_allclose(e[5], ev[5])
     np.testing.assert_allclose(e.as_numpy(), ev)
+
+
+def test_raw_events_append_preserves_polarity():  # type: ignore  # noqa: D103
+    events = types.RawEvents(
+        x=np.array([10, 11], dtype=np.int16),
+        y=np.array([20, 21], dtype=np.int16),
+        timestamp=np.array([0.1, 0.2], dtype=np.float64),
+        polarity=np.array([True, False], dtype=np.bool_),
+    )
+    event = types.RawEvent(
+        x=np.int16(12),
+        y=np.int16(22),
+        timestamp=np.float64(0.3),
+        polarity=True,
+    )
+
+    events.append(event)
+
+    np.testing.assert_array_equal(events.x, np.array([10, 11, 12], dtype=np.int16))
+    np.testing.assert_array_equal(events.y, np.array([20, 21, 22], dtype=np.int16))
+    np.testing.assert_allclose(events.timestamp, np.array([0.1, 0.2, 0.3]))
+    np.testing.assert_array_equal(events.polarity, np.array([True, False, True]))
+
+
+def test_raw_events_slice_returns_raw_events():  # type: ignore  # noqa: D103
+    events = types.RawEvents(
+        x=np.arange(20, dtype=np.int16),
+        y=np.arange(100, 120, dtype=np.int16),
+        timestamp=np.arange(20, dtype=np.float64) / 10.0,
+        polarity=np.arange(20) % 2 == 0,
+    )
+
+    sliced = events[10:20]
+
+    assert isinstance(sliced, types.RawEvents)
+    np.testing.assert_array_equal(sliced.x, events.x[10:20])
+    np.testing.assert_array_equal(sliced.y, events.y[10:20])
+    np.testing.assert_allclose(sliced.timestamp, events.timestamp[10:20])
+    np.testing.assert_array_equal(sliced.polarity, events.polarity[10:20])


### PR DESCRIPTION
Fix two correctness bugs in `RawEvents` and document existing dense NumPy layout

#### Issue
- `append()` appended x coordinate data to polarity producing mismatched columns
- Slice indexing such as `events[10:20]` was handled like a single event and returned a transposed dense array instead of a `RawEvents` batch

#### Fixes
- Append the incoming event's polarity to the polarity array
- Return a column preserving `RawEvents` object for slice indexes
- Add further tests for append, slicing, and the preserved dense layout