### PR TITLE
Add DSEC dataset wrappers

### DIFF
--- a/src/evlib/dataloaders/__init__.py
+++ b/src/evlib/dataloaders/__init__.py
@@ -6,7 +6,10 @@ from ._davis import DavisFrameSample
 from ._davis import DavisImuData
 from ._davis import DavisPoseData
 from ._davis import DavisRecordingLoader
+from ._dsec import DSECCamera
 from ._dsec import DSECDataLoader
+from ._dsec import DSECSample
+from ._dsec import DSECSplit
 from ._mvsec import MVSECDataLoader
 from ._mvsec_types import MVSECOdometryData
 from ._storage_common import LoadingType
@@ -20,7 +23,10 @@ __all__ = [
     "DavisImuData",
     "DavisPoseData",
     "DavisRecordingLoader",
+    "DSECCamera",
     "DSECDataLoader",
+    "DSECSample",
+    "DSECSplit",
     "DataLoaderBase",
     "LoadMode",
     "LoadingType",

--- a/src/evlib/datasets/__init__.py
+++ b/src/evlib/datasets/__init__.py
@@ -4,6 +4,9 @@ from ._base import BlockAccessDataset
 from ._base import EventDataset
 from ._base import IteratorAccessDataset
 from ._base import event_sample_collate
+from .dsec import DSECDataset
+from .dsec import DSECIterator
+from .dsec import dsec_collate_fn
 from .ecd import ECD_DAVIS240C_SENSOR_RESOLUTION
 from .ecd import ECD_REAL_SEQUENCES
 from .ecd import ECD_SEQUENCES
@@ -18,6 +21,8 @@ from .mvsec import mvsec_collate_fn
 
 __all__ = [
     "BlockAccessDataset",
+    "DSECDataset",
+    "DSECIterator",
     "ECDDataset",
     "ECDIterator",
     "ECD_DAVIS240C_SENSOR_RESOLUTION",
@@ -26,6 +31,7 @@ __all__ = [
     "ECD_SYNTHETIC_SEQUENCES",
     "EventDataset",
     "IteratorAccessDataset",
+    "dsec_collate_fn",
     "ecd_collate_fn",
     "event_sample_collate",
     "MVSECDataset",

--- a/src/evlib/datasets/dsec.py
+++ b/src/evlib/datasets/dsec.py
@@ -1,0 +1,200 @@
+"""DSEC dataset wrappers."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+
+from evlib.dataloaders import DSECCamera
+from evlib.dataloaders import DSECDataLoader
+from evlib.dataloaders import DSECSplit
+from evlib.dataloaders import LoadMode
+from evlib.dataloaders import ResidentLoadMode
+
+from ._base import BlockAccessDataset
+from ._base import IteratorAccessDataset
+from ._base import event_sample_collate
+
+
+dsec_collate_fn = event_sample_collate
+
+
+class DSECDataset(BlockAccessDataset):
+    """Map style dataset for one DSEC sequence.
+
+    The wrapper adds an indexed dataset contract to :class:`evlib.dataloaders.DSECDataLoader`.
+
+    Args:
+        root: Directory containing the DSEC dataset.
+        sequence: DSEC sequence name.
+        split: Dataset split containing the sequence.
+        camera: Event-camera stream to use, either ``"left"`` or ``"right"``.
+        load_images: Loading mode for rectified images.
+        load_flow_forward: Loading mode for forward optical flow.
+        load_flow_backward: Loading mode for backward optical flow.
+        load_disparity: Loading mode for disparity maps.
+        load_imu: Loading mode for IMU samples.
+        load_lidar: Loading mode for lidar point clouds.
+        load_calibration: Whether to load camera calibration.
+        load_rectify_map: Whether to load the event rectification map.
+        event_load_mode: Loading mode for event arrays.
+        prerectify_events: Whether to rectify cached events during initialization.
+    """
+
+    EVENT_SHAPE: tuple[int, int] = DSECDataLoader.EVENT_SHAPE
+    IMAGE_SHAPE: tuple[int, int] = DSECDataLoader.IMAGE_SHAPE
+
+    def __init__(
+        self,
+        root: str,
+        sequence: str,
+        split: DSECSplit = "train",
+        camera: DSECCamera = "left",
+        load_images: LoadMode = False,
+        load_flow_forward: LoadMode = False,
+        load_flow_backward: LoadMode = False,
+        load_disparity: LoadMode = False,
+        load_imu: LoadMode = False,
+        load_lidar: LoadMode = False,
+        load_calibration: bool = False,
+        load_rectify_map: bool = True,
+        event_load_mode: ResidentLoadMode = "lazy",
+        prerectify_events: bool = False,
+    ) -> None:
+        """Initialize a map style dataset for one DSEC sequence."""
+        self._loader = DSECDataLoader(
+            root,
+            sequence,
+            split=split,
+            camera=camera,
+            load_images=load_images,
+            load_flow_forward=load_flow_forward,
+            load_flow_backward=load_flow_backward,
+            load_disparity=load_disparity,
+            load_imu=load_imu,
+            load_lidar=load_lidar,
+            load_calibration=load_calibration,
+            load_rectify_map=load_rectify_map,
+            event_load_mode=event_load_mode,
+            prerectify_events=prerectify_events,
+        )
+
+    @property
+    def loader(self) -> DSECDataLoader:
+        """Return the underlying DSEC dataloader."""
+        return self._loader
+
+    @property
+    def root(self) -> str:
+        """Return the dataset root passed to the loader."""
+        return self._loader.root
+
+    @property
+    def sequence(self) -> str:
+        """Return the DSEC sequence name."""
+        return self._loader.sequence
+
+    @property
+    def split(self) -> DSECSplit:
+        """Return the dataset split."""
+        return self._loader.split
+
+    @property
+    def camera(self) -> DSECCamera:
+        """Return the selected event camera stream: ``"left"`` or ``"right"``."""
+        return self._loader.camera
+
+    def __getitem__(self, index: int) -> dict:
+        """Return the synchronized DSEC sample at an index."""
+        return cast(dict, self._loader.load_frame_sample(index))
+
+    def __len__(self) -> int:
+        """Return the number of synchronized samples."""
+        return self._loader.num_samples
+
+    def close(self) -> None:
+        """Release loader resources."""
+        self._loader.close()
+
+    def __repr__(self) -> str:
+        """Return a concise dataset representation."""
+        return (
+            f"{type(self).__name__}("
+            f"root={self.root!r}, "
+            f"sequence={self.sequence!r}, "
+            f"split={self.split!r}, "
+            f"camera={self.camera!r})"
+        )
+
+
+class DSECIterator(IteratorAccessDataset):
+    """Streaming iterator over one DSEC sequence.
+
+    Args:
+        root: Directory containing the DSEC dataset.
+        sequence: DSEC sequence name.
+        ``**kwargs``: Forwarded to :class:`DSECDataset`.
+    """
+
+    def __init__(self, root: str, sequence: str, **kwargs: Any) -> None:
+        """Initialize an iterator over one DSEC sequence."""
+        self._dataset = DSECDataset(root, sequence, **kwargs)
+        self._current = 0
+
+    @property
+    def dataset(self) -> DSECDataset:
+        """Return the underlying map-style dataset."""
+        return self._dataset
+
+    @property
+    def root(self) -> str:
+        """Return the dataset root passed to the loader."""
+        return self._dataset.root
+
+    @property
+    def sequence(self) -> str:
+        """Return the DSEC sequence name."""
+        return self._dataset.sequence
+
+    @property
+    def split(self) -> DSECSplit:
+        """Return the dataset split."""
+        return self._dataset.split
+
+    @property
+    def camera(self) -> DSECCamera:
+        """Return the selected event camera stream: ``"left"`` or ``"right"``."""
+        return self._dataset.camera
+
+    def __iter__(self) -> DSECIterator:
+        """Return the iterator reset to the first sample."""
+        self._current = 0
+        return self
+
+    def __next__(self) -> dict:
+        """Return the next synchronized sample."""
+        if self._current >= len(self._dataset):
+            raise StopIteration
+
+        current_index = self._current
+        sample = self._dataset[current_index]
+        self._current += 1
+        return sample
+
+    def reset(self) -> None:
+        """Reset the iteration cursor to the first sample."""
+        self._current = 0
+
+    def close(self) -> None:
+        """Release wrapped dataset resources."""
+        self._dataset.close()
+
+    def __repr__(self) -> str:
+        """Return a concise iterator representation."""
+        return (
+            f"{type(self).__name__}("
+            f"root={self.root!r}, "
+            f"sequence={self.sequence!r}, "
+            f"split={self.split!r}, "
+            f"camera={self.camera!r})"
+        )

--- a/tests/datasets/test_dsec.py
+++ b/tests/datasets/test_dsec.py
@@ -1,0 +1,121 @@
+"""Tests for the DSEC dataset wrappers."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from evlib.datasets import BlockAccessDataset
+from evlib.datasets import DSECDataset
+from evlib.datasets import DSECIterator
+from evlib.datasets import EventDataset
+from evlib.datasets import IteratorAccessDataset
+from evlib.datasets import dsec_collate_fn
+from evlib.datasets import event_sample_collate
+from evlib.types import RawEvents
+from tests.dataloaders.test_dsec import N_FLOW
+from tests.dataloaders.test_dsec import N_IMAGES
+from tests.dataloaders.test_dsec import SEQ
+from tests.dataloaders.test_dsec import _build_cleaned_dsec_tree
+
+
+@pytest.fixture()
+def dsec_dir(tmp_path: Path) -> Path:
+    """Build a synthetic DSEC sequence tree."""
+    _build_cleaned_dsec_tree(tmp_path)
+    return tmp_path
+
+
+class TestDSECDataset:
+    """Tests for map style DSEC dataset access."""
+
+    def test_dataset_basic_sample(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(
+            str(dsec_dir),
+            SEQ,
+            load_flow_forward=True,
+            load_images=True,
+            load_disparity=True,
+            event_load_mode="cached",
+        ) as dataset:
+            assert len(dataset) == N_FLOW
+            assert dataset.sequence == SEQ
+            assert dataset.split == "train"
+            assert dataset.camera == "left"
+            assert isinstance(dataset, BlockAccessDataset)
+            assert isinstance(dataset, EventDataset)
+
+            sample = dataset[0]
+            t_start, t_end = sample["timestamp"]
+            assert t_end > t_start
+            assert isinstance(sample["events"], RawEvents)
+            assert sample["image_start"] is not None
+            assert sample["image_end"] is not None
+            assert sample["flow"] is not None
+            assert sample["disparity"] is not None
+
+    def test_len_uses_image_intervals_without_flow(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(str(dsec_dir), SEQ, load_images=True) as dataset:
+            assert len(dataset) == N_IMAGES - 1
+
+    def test_loader_remains_available(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(str(dsec_dir), SEQ, load_images=True) as dataset:
+            assert dataset.loader.num_events > 0
+            assert len(dataset.loader.load_events(0, 10)) == 10
+
+    def test_repr_contains_dataset_identity(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(str(dsec_dir), SEQ, load_images=True) as dataset:
+            text = repr(dataset)
+            assert "DSECDataset" in text
+            assert str(dsec_dir) in text
+            assert SEQ in text
+            assert "train" in text
+            assert "left" in text
+
+
+class TestDSECIterator:
+    """Tests for iterable DSEC dataset access."""
+
+    def test_iterator_basic_and_reset(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECIterator(str(dsec_dir), SEQ, load_images=True) as iterator:
+            first_sample = next(iter(iterator))
+            next(iterator)
+
+            iterator.reset()
+            reset_sample = next(iterator)
+
+            assert isinstance(first_sample["events"], RawEvents)
+            assert first_sample["timestamp"] == reset_sample["timestamp"]
+
+    def test_iterator_stop(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECIterator(str(dsec_dir), SEQ, load_images=True) as iterator:
+            for _sample in iterator:
+                pass
+            with pytest.raises(StopIteration):
+                next(iterator)
+
+    def test_iterator_identity_and_type(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECIterator(str(dsec_dir), SEQ, load_images=True) as iterator:
+            assert isinstance(iterator, IteratorAccessDataset)
+            assert isinstance(iterator, EventDataset)
+            assert iterator.sequence == SEQ
+            assert iterator.split == "train"
+            assert iterator.camera == "left"
+            assert "DSECIterator" in repr(iterator)
+            assert SEQ in repr(iterator)
+
+
+class TestDSECCollate:
+    """Tests for DSEC collation."""
+
+    def test_collate_aliases_generic_helper(self) -> None:  # noqa: D102
+        assert dsec_collate_fn is event_sample_collate
+
+    def test_collate_stacks_interval_timestamps(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(str(dsec_dir), SEQ, load_images=True) as dataset:
+            batch = dsec_collate_fn([dataset[0], dataset[1]])
+
+        assert batch["timestamp"].shape == (2, 2)
+        assert batch["timestamp"].dtype == np.float64
+        assert isinstance(batch["events"], list)
+        assert isinstance(batch["events"][0], RawEvents)


### PR DESCRIPTION
Add map and iterator Dataset wrappers for DSEC.

- Add and export `DSECDataset`, `DSECIterator`, and `dsec_collate_fn`
- Delegate indexed samples and resource ownership to `DSECDataLoader`
- Add relevant test coverage