### PR TITLE
Added simple live view for event cam, working for Mac

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,3 @@
-pip==23.3.1
 nox==2026.2.9
 nox-poetry==1.2.0
 poetry==2.3.3

--- a/poetry.lock
+++ b/poetry.lock
@@ -5224,6 +5224,19 @@ tokenize-rt = ">=6.1.0"
 
 [[package]]
 name = "pyusb"
+version = "1.2.1"
+description = "Python USB access module"
+optional = false
+python-versions = ">=3.6.0"
+groups = ["main"]
+markers = "python_version == \"3.8\""
+files = [
+    {file = "pyusb-1.2.1-py3-none-any.whl", hash = "sha256:2b4c7cb86dbadf044dfb9d3a4ff69fd217013dbe78a792177a3feb172449ea36"},
+    {file = "pyusb-1.2.1.tar.gz", hash = "sha256:a4cc7404a203144754164b8b40994e2849fde1cfff06b08492f12fff9d9de7b9"},
+]
+
+[[package]]
+name = "pyusb"
 version = "1.3.1"
 description = "Easy USB access for Python"
 optional = false
@@ -7657,4 +7670,4 @@ ros = ["rosbags", "rosbags"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.13"
-content-hash = "818643ecbb91a2dace8cac9d074d246c75e14d9e7581f5bc2c0077d9d4197a93"
+content-hash = "5c788eb91d95c6149d989ab492fead5b02617fcc989e8332479aa10d0a9a1019"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7657,4 +7657,4 @@ ros = ["rosbags", "rosbags"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.13"
-content-hash = "5a6a2aa490d00673a297b4cc22d7233134a9fdefe09ea3910f8f3395cc131c0b"
+content-hash = "818643ecbb91a2dace8cac9d074d246c75e14d9e7581f5bc2c0077d9d4197a93"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5223,6 +5223,19 @@ files = [
 tokenize-rt = ">=6.1.0"
 
 [[package]]
+name = "pyusb"
+version = "1.3.1"
+description = "Easy USB access for Python"
+optional = false
+python-versions = ">=3.9.0"
+groups = ["main"]
+markers = "python_version >= \"3.9\""
+files = [
+    {file = "pyusb-1.3.1-py3-none-any.whl", hash = "sha256:bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430"},
+    {file = "pyusb-1.3.1.tar.gz", hash = "sha256:3af070b607467c1c164f49d5b0caabe8ac78dbed9298d703a8dbf9df4052d17e"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -7644,4 +7657,4 @@ ros = ["rosbags", "rosbags"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.13"
-content-hash = "39fbb1ae0fcbaefefbb801e1a012bc242d2e972eb3f29a82b791c31827a953b3"
+content-hash = "5a6a2aa490d00673a297b4cc22d7233134a9fdefe09ea3910f8f3395cc131c0b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ torch = [
 # check https://github.com/python-poetry/poetry/issues/6409 and https://github.com/pytorch/pytorch/issues/76557
 pillow = ">=9.5.0"
 matplotlib = ">=3.7.5"
+pyusb = {version = "^1.3.1", python = ">=3.9,<3.13"}
 
 [tool.poetry.dev-dependencies]
 Pygments = ">=2.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ torch = [
 # check https://github.com/python-poetry/poetry/issues/6409 and https://github.com/pytorch/pytorch/issues/76557
 pillow = ">=9.5.0"
 matplotlib = ">=3.7.5"
-pyusb = {version = ">=1.3.1", python = ">=3.8,<3.13"}
+pyusb = {version = ">=1.2.1", python = ">=3.8,<3.13"}
 
 [tool.poetry.dev-dependencies]
 Pygments = ">=2.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ torch = [
 # check https://github.com/python-poetry/poetry/issues/6409 and https://github.com/pytorch/pytorch/issues/76557
 pillow = ">=9.5.0"
 matplotlib = ">=3.7.5"
-pyusb = {version = ">=1.3.1", python = ">=3.9,<3.13"}
+pyusb = {version = ">=1.3.1", python = ">=3.8,<3.13"}
 
 [tool.poetry.dev-dependencies]
 Pygments = ">=2.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ torch = [
 # check https://github.com/python-poetry/poetry/issues/6409 and https://github.com/pytorch/pytorch/issues/76557
 pillow = ">=9.5.0"
 matplotlib = ">=3.7.5"
-pyusb = {version = "^1.3.1", python = ">=3.9,<3.13"}
+pyusb = {version = ">=1.3.1", python = ">=3.9,<3.13"}
 
 [tool.poetry.dev-dependencies]
 Pygments = ">=2.10.0"

--- a/src/decode_video.py
+++ b/src/decode_video.py
@@ -86,7 +86,8 @@ class FrameAccumulator:
         self._on = np.zeros((height, width), dtype=np.float32)
         self._off = np.zeros((height, width), dtype=np.float32)
         self._start_ts: float | None = None
-        self._current_slice: int | None = None
+        #self._current_slice: int | None = None
+        self._current_slice: int = 0
 
         # Precomputed once so render_frame() doesn't reallocate a kernel
         # every call.
@@ -125,7 +126,8 @@ class FrameAccumulator:
 
         # Split the chunk into runs of constant slice_idx.
         change_points = np.flatnonzero(np.diff(slice_idx)) + 1
-        boundaries = np.concatenate(([0], change_points, [len(t)]))
+        #boundaries = np.concatenate(([0], change_points, [len(t)]))
+        boundaries = np.concatenate((np.array([0]), change_points, np.array([len(t)])))
 
         for i in range(len(boundaries) - 1):
             s, e = boundaries[i], boundaries[i + 1]
@@ -170,8 +172,10 @@ class FrameAccumulator:
         off_strength = np.clip(self._off * self.intensity_scale, 0, 255).astype(np.uint8)
 
         if self._kernel is not None:
-            on_strength = cv2.dilate(on_strength, self._kernel)
-            off_strength = cv2.dilate(off_strength, self._kernel)
+            #on_strength = cv2.dilate(on_strength, self._kernel)
+            cv2.dilate(on_strength, self._kernel, dst=on_strength)
+            #off_strength = cv2.dilate(off_strength, self._kernel)
+            cv2.dilate(off_strength, self._kernel, dst=off_strength)
 
         on_mask = on_strength > self.strength_threshold
         off_mask = off_strength > self.strength_threshold
@@ -233,7 +237,8 @@ def decode_to_video(
         decay=decay,
     )
     writer = cv2.VideoWriter(
-        output_video, cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height)
+        #output_video, cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height)
+        output_video, cv2.VideoWriter.fourcc("m", "p", "4", "v"), fps, (width, height)
     )
 
     frames_written = 0

--- a/src/decode_video.py
+++ b/src/decode_video.py
@@ -1,0 +1,290 @@
+"""EVT3 to video renderer.
+
+Runs Evt3RawReader (see ``_evt3.py``, unmodified) over a recorded EVT3
+``.raw`` file and renders the decoded CD events into an MP4 video.
+
+Frame model: events are binned into fixed-duration time slices (default
+10ms of sensor time, from ``chunk.t``, which is in microseconds per
+Evt3RawReader's timestamp semantics). Each slice becomes one output frame.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import cv2 # video i/o
+import numpy as np
+import numpy.typing as npt
+
+from evlib.codec.fileformat._evt3 import Evt3EventChunk, Evt3RawReader
+
+# Rendering defaults, named so they read the same way at every call site.
+_DEFAULT_SLICE_US = 10_000.0
+_DEFAULT_ON_COLOR = (255, 80, 0)   # BGR -- brightness increase, blue for on
+_DEFAULT_OFF_COLOR = (0, 60, 255)  # BGR -- brightness decrease, ~red for off
+_DEFAULT_INTENSITY_SCALE = 80.0    # stretches event counts to visible brightness range. multiplier applied to per-pixel event count before clipping to 0-255
+_DEFAULT_STRENGTH_THRESHOLD = 20   # minimum brightness/strength (0-255) before a pixel is painted at all, reduces noise from very sparse events
+
+
+class FrameAccumulator:
+    """Bins decoded EVT3 CD events into time slices and renders BGR frames.
+
+    Events are accumulated per pixel, per polarity, into float32 arrays.
+    Each completed time slice is rendered into a BGR frame where pixel
+    brightness reflects event count (denser motion/edges render brighter),
+    with optional dilation for visibility and optional exponential decay
+    for motion trails.
+    """
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        slice_us: float = _DEFAULT_SLICE_US,
+        dot_radius_px: int = 0,
+        background: str = "white",
+        on_color: tuple[int, int, int] = _DEFAULT_ON_COLOR,
+        off_color: tuple[int, int, int] = _DEFAULT_OFF_COLOR,
+        decay: float = 0.0,
+        intensity_scale: float = _DEFAULT_INTENSITY_SCALE,
+        strength_threshold: int = _DEFAULT_STRENGTH_THRESHOLD,
+    ) -> None:
+        """Configure a frame accumulator.
+
+        Args:
+            width: Output frame width in pixels (EVK4 sensor width is 1280).
+            height: Output frame height in pixels (EVK4 sensor height is 720).
+            slice_us: Sensor-time duration, in microseconds, binned into one
+                output frame.
+            dot_radius_px: Dilation radius in pixels for event visibility.
+                0 disables dilation and renders raw, undilated pixels.
+            background: Canvas fill color before events are painted, either
+                "white" or "black".
+            on_color: BGR color for ON events (brightness increase).
+            off_color: BGR color for OFF events (brightness decrease).
+            decay: Trail persistence applied between slices. 0.0 hard-clears
+                every slice; values approaching 1.0 give long motion trails.
+            intensity_scale: Multiplier applied to per-pixel event count
+                before clipping to the 0-255 brightness range.
+            strength_threshold: Minimum brightness (0-255) required before a
+                pixel is painted, filtering out very sparse single events.
+        """
+        self.width = width
+        self.height = height
+        self.slice_us = slice_us
+        self.dot_radius_px = max(0, dot_radius_px)
+        self.background = background
+        self.on_color = np.array(on_color, dtype=np.uint8)
+        self.off_color = np.array(off_color, dtype=np.uint8)
+        self.decay = decay
+        self.intensity_scale = intensity_scale
+        self.strength_threshold = strength_threshold
+
+        self._on = np.zeros((height, width), dtype=np.float32)
+        self._off = np.zeros((height, width), dtype=np.float32)
+        self._start_ts: float | None = None
+        self._current_slice: int | None = None
+
+        # Precomputed once so render_frame() doesn't reallocate a kernel
+        # every call.
+        self._kernel: npt.NDArray[np.uint8] | None = None
+        if self.dot_radius_px > 0:
+            k = self.dot_radius_px * 2 + 1
+            self._kernel = np.ones((k, k), np.uint8)
+
+    def _clear_or_decay(self) -> None:
+        if self.decay > 0:
+            self._on *= self.decay
+            self._off *= self.decay
+        else:
+            self._on.fill(0)
+            self._off.fill(0)
+
+    def add_chunk(self, chunk: Evt3EventChunk) -> Iterator[npt.NDArray[np.uint8]]:
+        """Accumulate a decoded chunk and yield any completed frames.
+
+        Args:
+            chunk: Decoded CD events from Evt3RawReader.
+
+        Yields:
+            One rendered BGR frame per time slice completed by this chunk.
+        """
+        if len(chunk) == 0:
+            return
+
+        t, x, y, p = chunk.t, chunk.x, chunk.y, chunk.p
+
+        if self._start_ts is None:
+            self._start_ts = t[0]
+            self._current_slice = 0
+
+        slice_idx = np.floor((t - self._start_ts) / self.slice_us).astype(np.int64)
+
+        # Split the chunk into runs of constant slice_idx.
+        change_points = np.flatnonzero(np.diff(slice_idx)) + 1
+        boundaries = np.concatenate(([0], change_points, [len(t)]))
+
+        for i in range(len(boundaries) - 1):
+            s, e = boundaries[i], boundaries[i + 1]
+            idx = int(slice_idx[s])
+
+            if idx > self._current_slice:
+                # Flush the current frame, plus any fully-empty slices
+                # in between.
+                for _ in range(idx - self._current_slice):
+                    yield self.render_frame()
+                    self._clear_or_decay()
+                self._current_slice = idx
+
+            xs, ys, ps = x[s:e], y[s:e], p[s:e]
+
+            in_bounds = (xs >= 0) & (xs < self.width) & (ys >= 0) & (ys < self.height)
+            xs, ys, ps = xs[in_bounds], ys[in_bounds], ps[in_bounds]
+
+            # Flatten (y, x) into a single index and use bincount for
+            # scatter-accumulation -- substantially faster than np.add.at
+            # at EVT3's typical event rates.
+            on_flat = ys[ps].astype(np.int64) * self.width + xs[ps].astype(np.int64)
+            off_flat = ys[~ps].astype(np.int64) * self.width + xs[~ps].astype(np.int64)
+
+            if on_flat.size:
+                counts = np.bincount(on_flat, minlength=self.width * self.height)
+                self._on += counts.reshape(self.height, self.width)
+            if off_flat.size:
+                counts = np.bincount(off_flat, minlength=self.width * self.height)
+                self._off += counts.reshape(self.height, self.width)
+
+    def render_frame(self) -> npt.NDArray[np.uint8]:
+        """Render the current accumulator state into a BGR frame.
+
+        Returns:
+            A ``(height, width, 3)`` uint8 BGR frame.
+        """
+        bg_val = 255 if self.background == "white" else 0
+        frame = np.full((self.height, self.width, 3), bg_val, dtype=np.uint8)
+
+        on_strength = np.clip(self._on * self.intensity_scale, 0, 255).astype(np.uint8)
+        off_strength = np.clip(self._off * self.intensity_scale, 0, 255).astype(np.uint8)
+
+        if self._kernel is not None:
+            on_strength = cv2.dilate(on_strength, self._kernel)
+            off_strength = cv2.dilate(off_strength, self._kernel)
+
+        on_mask = on_strength > self.strength_threshold
+        off_mask = off_strength > self.strength_threshold
+
+        frame[on_mask] = self.on_color
+        frame[off_mask] = self.off_color
+        return frame
+
+    def flush(self) -> Iterator[npt.NDArray[np.uint8]]:
+        """Emit the final, partially-filled slice.
+
+        Call once after the reader is exhausted -- ``add_chunk`` only
+        emits a frame once a later slice index is observed, so the last
+        slice otherwise never gets rendered.
+
+        Yields:
+            The final rendered BGR frame, if any events were accumulated.
+        """
+        if self._start_ts is not None:
+            yield self.render_frame()
+
+
+def decode_to_video(
+    raw_path: str,
+    output_video: str = "evk4_capture.mp4",
+    width: int = 1280,
+    height: int = 720,
+    slice_us: float = _DEFAULT_SLICE_US,
+    fps: float = 100.0,
+    reader_chunk_size: int = 16384,
+    dot_radius_px: int = 0,
+    background: str = "white",
+    decay: float = 0.0,
+) -> str:
+    """Decode an EVT3 ``.raw`` file into an MP4 video.
+
+    Args:
+        raw_path: Path to the recorded EVT3 ``.raw`` file.
+        output_video: Output video file path.
+        width: Sensor width in pixels (EVK4 is 1280).
+        height: Sensor height in pixels (EVK4 is 720).
+        slice_us: Event accumulation window, in microseconds.
+        fps: Output video frame rate.
+        reader_chunk_size: Events per chunk requested from Evt3RawReader.
+        dot_radius_px: Dilation radius in pixels (0 = raw pixel detail).
+        background: Canvas background, "white" or "black".
+        decay: Trail persistence, 0.0-0.95.
+
+    Returns:
+        The output video path, unchanged from ``output_video``.
+    """
+    reader = Evt3RawReader(raw_path, chunk_size=reader_chunk_size)
+    accumulator = FrameAccumulator(
+        width=width,
+        height=height,
+        slice_us=slice_us,
+        dot_radius_px=dot_radius_px,
+        background=background,
+        decay=decay,
+    )
+    writer = cv2.VideoWriter(
+        output_video, cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height)
+    )
+
+    frames_written = 0
+    events_seen = 0
+
+    try:
+        for chunk in reader.read_chunks():
+            events_seen += len(chunk)
+            for frame in accumulator.add_chunk(chunk):
+                writer.write(frame)
+                frames_written += 1
+        for frame in accumulator.flush():
+            writer.write(frame)
+            frames_written += 1
+    finally:
+        reader.close()
+        writer.release()
+
+    print(f"Decoded {events_seen} events, wrote {frames_written} frames -> {output_video}")
+    if events_seen == 0:
+        print(
+            "WARNING: zero events decoded. Check that the .raw file actually "
+            "contains EVT3 data (nonzero size) and that width/height match "
+            "the sensor (EVK4 is 1280x720)."
+        )
+    return output_video
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Decode a recorded EVT3 .raw file into a video")
+    p.add_argument("raw_file", help="Path to the recorded .raw file")
+    p.add_argument("--output", default="evk4_capture.mp4")
+    p.add_argument("--width", type=int, default=1280)
+    p.add_argument("--height", type=int, default=720)
+    p.add_argument("--slice-us", type=float, default=_DEFAULT_SLICE_US, help="Event accumulation window, microseconds")
+    p.add_argument("--fps", type=float, default=100.0, help="Output video frame rate")
+    p.add_argument("--reader-chunk-size", type=int, default=16384, help="Events per chunk from Evt3RawReader")
+    p.add_argument("--dot-radius", type=int, default=0, help="Dilation radius in pixels (0 = raw pixel detail)")
+    p.add_argument("--background", choices=["white", "black"], default="white")
+    p.add_argument("--decay", type=float, default=0.0, help="Trail persistence, 0-0.95")
+    args = p.parse_args()
+
+    decode_to_video(
+        args.raw_file,
+        output_video=args.output,
+        width=args.width,
+        height=args.height,
+        slice_us=args.slice_us,
+        fps=args.fps,
+        reader_chunk_size=args.reader_chunk_size,
+        dot_radius_px=args.dot_radius,
+        background=args.background,
+        decay=args.decay,
+    )

--- a/src/evlib/codec/usb_link.py
+++ b/src/evlib/codec/usb_link.py
@@ -143,7 +143,8 @@ class EVK4Link:
             The register's current 32-bit value.
         """
         raw = self.tz(PROP_REG32, struct.pack("<III", device_id, addr, 1))
-        return struct.unpack("<I", raw[8:12])[0]
+        #return struct.unpack("<I", raw[8:12])[0]
+        return int(struct.unpack("<I", raw[8:12])[0])
 
     def reg_write(self, addr: int, val: int, device_id: int = 0) -> None:
         """Write a 32-bit device register.

--- a/src/live_view.py
+++ b/src/live_view.py
@@ -1,0 +1,183 @@
+"""Live preview for the EVK4 event camera.
+
+Shows decoded events in a window while the camera is moved, so it's
+possible to see directly whether sparse output is expected sensor
+behavior (only motion/edges generate events) or an actual problem.
+
+Everything read off the device is also written to a ``.raw`` file as it
+arrives, so the session can be re-decoded afterward with
+``decode_video.py`` for a lossless, full-resolution result -- this live
+view intentionally drops stale frames for responsiveness (see
+``LiveEvt3Reader`` and the decode loop in ``live_view()`` below), but the
+``.raw`` file itself is byte-identical to what a plain recorder would
+produce.
+
+Usage:
+    python3 live_view.py --output live_session.raw
+
+Press 'q' in the preview window to stop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import numpy.typing as npt
+
+from usb_link import EVK4Link
+
+sys.path.insert(0, str(Path("./event-vision-library/src")))
+from evlib.codec.fileformat._evt3 import Evt3RawReader
+from decode_video import FrameAccumulator
+
+_DEFAULT_SLICE_US = 20_000.0
+_DEFAULT_CHUNK_SIZE = 16384
+_DEFAULT_CHUNKS_PER_FLUSH = 20
+
+
+class LiveEvt3Reader(Evt3RawReader):
+    """Evt3RawReader variant for a file another process is still appending to.
+
+    The base Evt3RawReader sets ``self._finished = True`` permanently on
+    any empty read, which is correct for a closed file but wrong for a
+    ``.raw`` file that ``live_view()`` is writing to concurrently. This
+    override treats an empty read as "nothing new yet" rather than "the
+    stream is over forever".
+    """
+
+    def _read_word_block(self) -> npt.NDArray[np.uint16] | None:
+        data = self.file.read(self.read_size)
+        if not data:
+            # Transient: no new data currently on disk. Do NOT set
+            # self._finished -- more bytes may show up on the next call.
+            return None
+
+        if self._pending_byte:
+            data = self._pending_byte + data
+            self._pending_byte = b""
+
+        usable_size = len(data) - (len(data) % 2)
+        if usable_size != len(data):
+            self._pending_byte = data[-1:]
+            data = data[:usable_size]
+
+        if not data:
+            return None
+        return np.frombuffer(data, dtype="<u2")
+
+
+def live_view(
+    output_raw_path: str = "live_session.raw",
+    width: int = 1280,
+    height: int = 720,
+    slice_us: float = _DEFAULT_SLICE_US,
+    chunk_size: int = _DEFAULT_CHUNK_SIZE,
+    chunks_per_flush: int = _DEFAULT_CHUNKS_PER_FLUSH,
+    attempt_run_start: bool = True,
+    window_name: str = "EVK4 Live View (press q to stop)",
+) -> None:
+    """Stream, record, and preview EVT3 events from the EVK4 in real time.
+
+    Args:
+        output_raw_path: Path the raw EVT3 byte stream is written to.
+        width: Sensor width in pixels (EVK4 is 1280).
+        height: Sensor height in pixels (EVK4 is 720).
+        slice_us: Event accumulation window, in microseconds, per rendered
+            frame.
+        chunk_size: Bytes requested per USB read from EVK4Link.stream().
+        chunks_per_flush: Number of USB reads between disk flush() calls.
+            Flushing every read forces a disk sync per chunk and can stall
+            the capture loop; batching flushes trades a small durability
+            window for throughput.
+        attempt_run_start: Whether to call EVK4Link.run_start() before
+            streaming begins.
+        window_name: Title of the OpenCV preview window.
+    """
+    link = EVK4Link()
+
+    if attempt_run_start:
+        print("Attempting run_start() streaming init...")
+        link.run_start()
+
+    # Create the file first (even empty) so the reader can open it.
+    open(output_raw_path, "wb").close()
+
+    f_out = open(output_raw_path, "ab")
+    reader = LiveEvt3Reader(output_raw_path)
+    accumulator = FrameAccumulator(width=width, height=height, slice_us=slice_us)
+
+    print(f"Live view running -- writing to {output_raw_path}, press 'q' in the window to stop.")
+    bytes_written = 0
+    events_seen = 0
+    chunk_counter = 0
+
+    try:
+        for raw in link.stream(chunk_size=chunk_size):
+            if raw:
+                f_out.write(raw)
+                chunk_counter += 1
+                if chunk_counter % chunks_per_flush == 0:
+                    f_out.flush()
+                bytes_written += len(raw)
+
+            # Decode every chunk currently available, not just one -- a
+            # single next_chunk() per USB read lets the decode backlog
+            # grow silently whenever bytes arrive faster than one chunk
+            # per iteration, causing the preview to drift behind real
+            # camera motion.
+            latest_frame = None
+            while True:
+                try:
+                    chunk = reader.next_chunk()
+                except StopIteration:
+                    break
+
+                events_seen += len(chunk)
+                for frame in accumulator.add_chunk(chunk):
+                    # Keep only the newest frame for display -- pushing
+                    # every intermediate frame to cv2.imshow during a
+                    # catch-up burst is what stalls the GUI. The .raw
+                    # file on disk still has every event for offline,
+                    # lossless reconstruction via decode_video.py.
+                    latest_frame = frame
+
+            if latest_frame is not None:
+                cv2.imshow(window_name, latest_frame)
+
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                break
+    finally:
+        f_out.flush()
+        f_out.close()
+        reader.close()
+        cv2.destroyAllWindows()
+
+    print(f"Stopped. {bytes_written} bytes recorded, {events_seen} events decoded live -> {output_raw_path}")
+    if bytes_written == 0:
+        print("WARNING: no bytes received -- same run_start()/endpoint issue as before, not a live-view problem.")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Live preview of EVK4 events while recording")
+    p.add_argument("--output", default="live_session.raw")
+    p.add_argument("--width", type=int, default=1280)
+    p.add_argument("--height", type=int, default=720)
+    p.add_argument("--slice-us", type=float, default=_DEFAULT_SLICE_US)
+    p.add_argument("--chunk-size", type=int, default=_DEFAULT_CHUNK_SIZE)
+    p.add_argument("--chunks-per-flush", type=int, default=_DEFAULT_CHUNKS_PER_FLUSH)
+    p.add_argument("--no-run-start", action="store_true")
+    args = p.parse_args()
+
+    live_view(
+        output_raw_path=args.output,
+        width=args.width,
+        height=args.height,
+        slice_us=args.slice_us,
+        chunk_size=args.chunk_size,
+        chunks_per_flush=args.chunks_per_flush,
+        attempt_run_start=not args.no_run_start,
+    )

--- a/src/live_view.py
+++ b/src/live_view.py
@@ -28,7 +28,7 @@ import cv2
 import numpy as np
 import numpy.typing as npt
 
-from usb_link import EVK4Link
+from evlib.codec.usb_link import EVK4Link
 
 sys.path.insert(0, str(Path("./event-vision-library/src")))
 from evlib.codec.fileformat._evt3 import Evt3RawReader

--- a/src/usb_link.py
+++ b/src/usb_link.py
@@ -1,0 +1,222 @@
+"""Low-level pyusb connection to the EVK4 (04b4:00f5).
+
+Implements the TZ property request/response framing used to talk to the
+device, plus bulk-endpoint discovery and the streaming data path.
+
+Everything in here is either:
+  (a) verified against hardware already (device discovery, reg_read), or
+  (b) explicitly marked UNVERIFIED (run_start) pending confirmation on
+      real hardware.
+
+No OpenEB source is read or referenced at runtime -- this is a standalone
+reimplementation of the wire protocol.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Iterator
+
+import usb.core
+import usb.util
+
+VENDOR_ID = 0x04B4
+PRODUCT_ID = 0x00F5
+
+# TZ property IDs, from the request/response framing already confirmed
+# working against hardware.
+PROP_REG32 = 0x10102
+PROP_WRITE_FLAG = 0x40000000
+PROP_REJECT_FLAG = 0x80000000
+
+_TZ_RESPONSE_SIZE = 512
+_TZ_HEADER_FORMAT = "<II"
+_USB_TIMEOUT_ERRNOS = (110, 60)  # ETIMEDOUT variants raised by libusb backends
+
+
+class EVK4Link:
+    """USB bulk-transfer link to an EVK4 event camera."""
+
+    def __init__(self, vendor_id: int = VENDOR_ID, product_id: int = PRODUCT_ID) -> None:
+        """Open the EVK4 device and resolve its bulk endpoints.
+
+        Args:
+            vendor_id: USB vendor ID to search for.
+            product_id: USB product ID to search for.
+
+        Raises:
+            RuntimeError: If no matching device is found, or if the
+                expected bulk endpoint layout (1 OUT, 2 IN) isn't present.
+        """
+        self.dev = usb.core.find(idVendor=vendor_id, idProduct=product_id)
+        if self.dev is None:
+            raise RuntimeError(
+                f"EVK4 not found ({vendor_id:#06x}:{product_id:#06x}). "
+                f"Check `system_profiler SPUSBDataType | grep -A15 0x04b4`."
+            )
+        self.dev.set_configuration()
+        intf = self.dev.get_active_configuration()[(0, 0)]
+        bulk_eps = [
+            e for e in intf
+            if usb.util.endpoint_type(e.bmAttributes) == usb.util.ENDPOINT_TYPE_BULK
+        ]
+        if len(bulk_eps) < 3:
+            raise RuntimeError(
+                f"Expected 3 bulk endpoints (ctrl-out, ctrl-in, data-in), found {len(bulk_eps)}."
+            )
+
+        out_eps = [e for e in bulk_eps if usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_OUT]
+        in_eps = [e for e in bulk_eps if usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_IN]
+
+        if len(out_eps) != 1 or len(in_eps) != 2:
+            raise RuntimeError(
+                f"Expected exactly 1 OUT and 2 IN bulk endpoints, "
+                f"found {len(out_eps)} OUT and {len(in_eps)} IN. "
+                f"Run inspect_endpoints.py and adjust endpoint selection manually."
+            )
+
+        self.ep_out = out_eps[0]
+        out_number = self.ep_out.bEndpointAddress & 0x0F
+
+        # The IN endpoint sharing the OUT endpoint's number is treated as
+        # the paired control-response channel; the other IN endpoint is
+        # the data stream. This matches the observed layout (0x02 OUT /
+        # 0x82 IN paired, 0x81 IN as data) but is inferred from numbering,
+        # not verified against firmware documentation -- worth revisiting
+        # if streaming still doesn't work.
+        matching = [e for e in in_eps if (e.bEndpointAddress & 0x0F) == out_number]
+        if len(matching) == 1:
+            self.ep_in = matching[0]
+            self.ep_data = [e for e in in_eps if e is not self.ep_in][0]
+        else:
+            # Fall back to address order if the numbering heuristic
+            # doesn't apply.
+            self.ep_in, self.ep_data = sorted(in_eps, key=lambda e: e.bEndpointAddress)
+
+        print(
+            f"Resolved endpoints: OUT={self.ep_out.bEndpointAddress:#04x}, "
+            f"ctrl-IN={self.ep_in.bEndpointAddress:#04x}, "
+            f"data-IN={self.ep_data.bEndpointAddress:#04x}"
+        )
+
+    # -- low-level property request/response ---------------------------------
+
+    def tz(
+        self,
+        prop: int,
+        payload: bytes = b"",
+        timeout_write: int = 1000,
+        timeout_read: int = 10000,
+    ) -> bytes:
+        """Send a TZ property request and return its response payload.
+
+        Args:
+            prop: TZ property ID, optionally OR'd with PROP_WRITE_FLAG.
+            payload: Request payload bytes.
+            timeout_write: Write timeout, in milliseconds.
+            timeout_read: Read timeout, in milliseconds.
+
+        Returns:
+            The response payload, with the 8-byte TZ header stripped.
+
+        Raises:
+            RuntimeError: If the device rejects the property request.
+        """
+        header = struct.pack(_TZ_HEADER_FORMAT, prop, len(payload))
+        self.dev.write(self.ep_out.bEndpointAddress, header + payload, timeout=timeout_write)
+        resp = bytes(self.dev.read(self.ep_in.bEndpointAddress, _TZ_RESPONSE_SIZE, timeout=timeout_read))
+        p, sz = struct.unpack(_TZ_HEADER_FORMAT, resp[:8])
+        if p & PROP_REJECT_FLAG:
+            raise RuntimeError(f"device rejected property {prop:#x}")
+        return resp[8:8 + sz]
+
+    # -- register access (verified read path) ---------------------------------
+
+    def reg_read(self, addr: int, device_id: int = 0) -> int:
+        """Read a 32-bit device register.
+
+        Args:
+            addr: Register address.
+            device_id: TZ device ID the register belongs to.
+
+        Returns:
+            The register's current 32-bit value.
+        """
+        raw = self.tz(PROP_REG32, struct.pack("<III", device_id, addr, 1))
+        return struct.unpack("<I", raw[8:12])[0]
+
+    def reg_write(self, addr: int, val: int, device_id: int = 0) -> None:
+        """Write a 32-bit device register.
+
+        Args:
+            addr: Register address.
+            val: Value to write.
+            device_id: TZ device ID the register belongs to.
+        """
+        self.tz(PROP_REG32 | PROP_WRITE_FLAG, struct.pack("<III", device_id, addr, val))
+
+    def reg_write_field(self, addr: int, data: int, mask: int, device_id: int = 0) -> None:
+        """Read-modify-write a masked field within a register.
+
+        Args:
+            addr: Register address.
+            data: New field value (only bits under ``mask`` are used).
+            mask: Bitmask selecting which bits of the register to modify.
+            device_id: TZ device ID the register belongs to.
+        """
+        current = self.reg_read(addr, device_id)
+        new_val = (current & ~mask) | (data & mask)
+        self.reg_write(addr, new_val, device_id)
+
+    # -- streaming control ------------------------------------------------------
+
+    def run_start(self) -> None:
+        """Run the short streaming-init register sequence.
+
+        UNVERIFIED on hardware as of this module being written. This is
+        the short 5-op sequence, not the full ~40-op cold-boot init. Try
+        this first; if the data endpoint stays empty, the full init table
+        is likely needed instead (not included here).
+        """
+        self.reg_write(0x0000B000, 0x000002F9)
+        self.reg_write(0x00009028, 0x00000000)
+        self.reg_write_field(0x00009008, 0x645, 0x00000001)
+        self.reg_write(0x0000002C, 0x0022C724)          # Analog START
+        self.reg_write_field(0x00000004, 0xF0005442, 0x00000400)
+
+    def read_data(self, size: int = 16384, timeout: int = 2000) -> bytes:
+        """Pull one chunk of raw bulk data off the streaming endpoint.
+
+        Args:
+            size: Maximum number of bytes to read.
+            timeout: Read timeout, in milliseconds.
+
+        Returns:
+            The bytes read from the data endpoint.
+        """
+        return bytes(self.dev.read(self.ep_data.bEndpointAddress, size, timeout=timeout))
+
+    def stream(self, chunk_size: int = 16384, timeout: int = 2000) -> Iterator[bytes]:
+        """Yield raw byte chunks from the device until interrupted or a read fails.
+
+        Args:
+            chunk_size: Maximum number of bytes requested per read.
+            timeout: Read timeout, in milliseconds.
+
+        Yields:
+            Raw bytes read from the data endpoint. An empty ``bytes``
+            object is yielded on a read timeout with no data, which is
+            common when the sensor is idle -- this surfaces the timeout
+            to the caller rather than treating it as end of stream.
+
+        Raises:
+            usb.core.USBError: For any USB error other than a timeout.
+        """
+        while True:
+            try:
+                yield self.read_data(chunk_size, timeout)
+            except usb.core.USBError as e:
+                if e.errno in _USB_TIMEOUT_ERRNOS:
+                    yield b""
+                    continue
+                raise

--- a/tests/codec/test_usb_link.py
+++ b/tests/codec/test_usb_link.py
@@ -17,12 +17,12 @@ from evlib.codec.usb_link import EVK4Link, PROP_REG32, PROP_REJECT_FLAG, PROP_WR
 
 
 class FakeEndpoint:
-    def __init__(self, address, transfer_type=usb.util.ENDPOINT_TYPE_BULK):
+    def __init__(self, address: int, transfer_type: int = usb.util.ENDPOINT_TYPE_BULK) -> None:
         self.bEndpointAddress = address
         self.bmAttributes = transfer_type
 
 
-def _make_device(endpoints):
+def _make_device(endpoints: list[FakeEndpoint]) -> MagicMock:
     dev = MagicMock()
     dev.get_active_configuration.return_value = {(0, 0): endpoints}
     return dev
@@ -32,20 +32,20 @@ def _make_device(endpoints):
 # Endpoint discovery
 # ---------------------------------------------------------------------------
 
-def test_raises_when_device_not_found():
+def test_raises_when_device_not_found() -> None:
     with patch("usb.core.find", return_value=None):
         with pytest.raises(RuntimeError, match="EVK4 not found"):
             EVK4Link()
 
 
-def test_raises_when_fewer_than_three_bulk_endpoints():
+def test_raises_when_fewer_than_three_bulk_endpoints() -> None:
     dev = _make_device([FakeEndpoint(0x02), FakeEndpoint(0x81)])
     with patch("usb.core.find", return_value=dev):
         with pytest.raises(RuntimeError, match="Expected 3 bulk endpoints"):
             EVK4Link()
 
 
-def test_raises_when_endpoint_directions_are_wrong_shape():
+def test_raises_when_endpoint_directions_are_wrong_shape() -> None:
     # 2 OUT, 1 IN instead of the required 1 OUT, 2 IN.
     dev = _make_device([FakeEndpoint(0x02), FakeEndpoint(0x03), FakeEndpoint(0x81)])
     with patch("usb.core.find", return_value=dev):
@@ -53,7 +53,7 @@ def test_raises_when_endpoint_directions_are_wrong_shape():
             EVK4Link()
 
 
-def test_correctly_assigns_endpoints_by_matching_number():
+def test_correctly_assigns_endpoints_by_matching_number() -> None:
     # OUT=0x02, matching ctrl-IN=0x82, data-IN=0x81.
     dev = _make_device([FakeEndpoint(0x02), FakeEndpoint(0x82), FakeEndpoint(0x81)])
     with patch("usb.core.find", return_value=dev):
@@ -63,7 +63,7 @@ def test_correctly_assigns_endpoints_by_matching_number():
     assert link.ep_data.bEndpointAddress == 0x81
 
 
-def test_falls_back_to_address_order_when_no_number_match():
+def test_falls_back_to_address_order_when_no_number_match() -> None:
     dev = _make_device([FakeEndpoint(0x05), FakeEndpoint(0x83), FakeEndpoint(0x81)])
     with patch("usb.core.find", return_value=dev):
         link = EVK4Link()
@@ -75,7 +75,7 @@ def test_falls_back_to_address_order_when_no_number_match():
 # tz / register access
 # ---------------------------------------------------------------------------
 
-def _linked_with_mock_dev():
+def _linked_with_mock_dev() -> EVK4Link:
     link = EVK4Link.__new__(EVK4Link)
     link.dev = MagicMock()
     link.ep_out = FakeEndpoint(0x02)
@@ -84,7 +84,7 @@ def _linked_with_mock_dev():
     return link
 
 
-def test_tz_sends_correct_header_and_returns_stripped_payload():
+def test_tz_sends_correct_header_and_returns_stripped_payload() -> None:
     link = _linked_with_mock_dev()
     payload = b"\x01\x02\x03\x04"
     resp = struct.pack("<II", PROP_REG32, 4) + b"\xAA\xBB\xCC\xDD"
@@ -97,7 +97,7 @@ def test_tz_sends_correct_header_and_returns_stripped_payload():
     assert result == b"\xAA\xBB\xCC\xDD"
 
 
-def test_tz_raises_when_device_rejects_property():
+def test_tz_raises_when_device_rejects_property() -> None:
     link = _linked_with_mock_dev()
     resp = struct.pack("<II", PROP_REG32 | PROP_REJECT_FLAG, 0)
     link.dev.read.return_value = resp.ljust(512, b"\x00")
@@ -106,7 +106,7 @@ def test_tz_raises_when_device_rejects_property():
         link.tz(PROP_REG32)
 
 
-def test_reg_read_returns_correct_int_value():
+def test_reg_read_returns_correct_int_value() -> None:
     link = _linked_with_mock_dev()
     resp = struct.pack("<II", PROP_REG32, 12) + b"\x00" * 8 + struct.pack("<I", 0xDEADBEEF)
     link.dev.read.return_value = resp.ljust(512, b"\x00")
@@ -117,7 +117,7 @@ def test_reg_read_returns_correct_int_value():
     assert isinstance(value, int)
 
 
-def test_reg_write_sets_write_flag_and_sends_value():
+def test_reg_write_sets_write_flag_and_sends_value() -> None:
     link = _linked_with_mock_dev()
     link.dev.read.return_value = struct.pack("<II", 0, 0).ljust(512, b"\x00")
 
@@ -131,7 +131,7 @@ def test_reg_write_sets_write_flag_and_sends_value():
     assert val == 0x5678
 
 
-def test_reg_write_field_only_changes_masked_bits():
+def test_reg_write_field_only_changes_masked_bits() -> None:
     link = _linked_with_mock_dev()
     with patch.object(link, "reg_read", return_value=0b1111_0000), \
          patch.object(link, "reg_write") as mock_write:
@@ -146,7 +146,7 @@ def test_reg_write_field_only_changes_masked_bits():
 # streaming
 # ---------------------------------------------------------------------------
 
-def test_run_start_writes_expected_number_of_registers():
+def test_run_start_writes_expected_number_of_registers() -> None:
     link = _linked_with_mock_dev()
     with patch.object(link, "reg_write") as mock_write, \
          patch.object(link, "reg_write_field") as mock_write_field:
@@ -156,7 +156,7 @@ def test_run_start_writes_expected_number_of_registers():
     assert mock_write_field.call_count == 2
 
 
-def test_read_data_returns_bytes_from_data_endpoint():
+def test_read_data_returns_bytes_from_data_endpoint() -> None:
     link = _linked_with_mock_dev()
     link.dev.read.return_value = b"\x01\x02\x03"
 
@@ -166,7 +166,7 @@ def test_read_data_returns_bytes_from_data_endpoint():
     link.dev.read.assert_called_once_with(link.ep_data.bEndpointAddress, 1024, timeout=500)
 
 
-def test_stream_yields_empty_bytes_on_timeout_then_continues():
+def test_stream_yields_empty_bytes_on_timeout_then_continues() -> None:
     link = _linked_with_mock_dev()
     timeout_error = usb.core.USBError("timed out")
     timeout_error.errno = 60
@@ -178,7 +178,7 @@ def test_stream_yields_empty_bytes_on_timeout_then_continues():
     assert next(gen) == b"\x01\x02\x03"
 
 
-def test_stream_reraises_non_timeout_errors():
+def test_stream_reraises_non_timeout_errors() -> None:
     link = _linked_with_mock_dev()
     error = usb.core.USBError("permission denied")
     error.errno = 13  # not a recognized timeout errno

--- a/tests/codec/test_usb_link.py
+++ b/tests/codec/test_usb_link.py
@@ -1,0 +1,188 @@
+"""EVK4Link (usb_link.py) tests.
+
+No real hardware needed: usb.core.find is patched to return a small
+fake device object, and pyusb's real usb.util functions classify its
+fake endpoints (they're pure bit-masking, no hardware required).
+"""
+from __future__ import annotations
+
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+import usb.core
+import usb.util
+
+from evlib.codec.usb_link import EVK4Link, PROP_REG32, PROP_REJECT_FLAG, PROP_WRITE_FLAG
+
+
+class FakeEndpoint:
+    def __init__(self, address, transfer_type=usb.util.ENDPOINT_TYPE_BULK):
+        self.bEndpointAddress = address
+        self.bmAttributes = transfer_type
+
+
+def _make_device(endpoints):
+    dev = MagicMock()
+    dev.get_active_configuration.return_value = {(0, 0): endpoints}
+    return dev
+
+
+# ---------------------------------------------------------------------------
+# Endpoint discovery
+# ---------------------------------------------------------------------------
+
+def test_raises_when_device_not_found():
+    with patch("usb.core.find", return_value=None):
+        with pytest.raises(RuntimeError, match="EVK4 not found"):
+            EVK4Link()
+
+
+def test_raises_when_fewer_than_three_bulk_endpoints():
+    dev = _make_device([FakeEndpoint(0x02), FakeEndpoint(0x81)])
+    with patch("usb.core.find", return_value=dev):
+        with pytest.raises(RuntimeError, match="Expected 3 bulk endpoints"):
+            EVK4Link()
+
+
+def test_raises_when_endpoint_directions_are_wrong_shape():
+    # 2 OUT, 1 IN instead of the required 1 OUT, 2 IN.
+    dev = _make_device([FakeEndpoint(0x02), FakeEndpoint(0x03), FakeEndpoint(0x81)])
+    with patch("usb.core.find", return_value=dev):
+        with pytest.raises(RuntimeError, match="Expected exactly 1 OUT and 2 IN"):
+            EVK4Link()
+
+
+def test_correctly_assigns_endpoints_by_matching_number():
+    # OUT=0x02, matching ctrl-IN=0x82, data-IN=0x81.
+    dev = _make_device([FakeEndpoint(0x02), FakeEndpoint(0x82), FakeEndpoint(0x81)])
+    with patch("usb.core.find", return_value=dev):
+        link = EVK4Link()
+    assert link.ep_out.bEndpointAddress == 0x02
+    assert link.ep_in.bEndpointAddress == 0x82
+    assert link.ep_data.bEndpointAddress == 0x81
+
+
+def test_falls_back_to_address_order_when_no_number_match():
+    dev = _make_device([FakeEndpoint(0x05), FakeEndpoint(0x83), FakeEndpoint(0x81)])
+    with patch("usb.core.find", return_value=dev):
+        link = EVK4Link()
+    assert link.ep_in.bEndpointAddress == 0x81
+    assert link.ep_data.bEndpointAddress == 0x83
+
+
+# ---------------------------------------------------------------------------
+# tz / register access
+# ---------------------------------------------------------------------------
+
+def _linked_with_mock_dev():
+    link = EVK4Link.__new__(EVK4Link)
+    link.dev = MagicMock()
+    link.ep_out = FakeEndpoint(0x02)
+    link.ep_in = FakeEndpoint(0x82)
+    link.ep_data = FakeEndpoint(0x81)
+    return link
+
+
+def test_tz_sends_correct_header_and_returns_stripped_payload():
+    link = _linked_with_mock_dev()
+    payload = b"\x01\x02\x03\x04"
+    resp = struct.pack("<II", PROP_REG32, 4) + b"\xAA\xBB\xCC\xDD"
+    link.dev.read.return_value = resp.ljust(512, b"\x00")
+
+    result = link.tz(PROP_REG32, payload)
+
+    sent = link.dev.write.call_args[0][1]
+    assert sent == struct.pack("<II", PROP_REG32, len(payload)) + payload
+    assert result == b"\xAA\xBB\xCC\xDD"
+
+
+def test_tz_raises_when_device_rejects_property():
+    link = _linked_with_mock_dev()
+    resp = struct.pack("<II", PROP_REG32 | PROP_REJECT_FLAG, 0)
+    link.dev.read.return_value = resp.ljust(512, b"\x00")
+
+    with pytest.raises(RuntimeError, match="device rejected property"):
+        link.tz(PROP_REG32)
+
+
+def test_reg_read_returns_correct_int_value():
+    link = _linked_with_mock_dev()
+    resp = struct.pack("<II", PROP_REG32, 12) + b"\x00" * 8 + struct.pack("<I", 0xDEADBEEF)
+    link.dev.read.return_value = resp.ljust(512, b"\x00")
+
+    value = link.reg_read(0x1234)
+
+    assert value == 0xDEADBEEF
+    assert isinstance(value, int)
+
+
+def test_reg_write_sets_write_flag_and_sends_value():
+    link = _linked_with_mock_dev()
+    link.dev.read.return_value = struct.pack("<II", 0, 0).ljust(512, b"\x00")
+
+    link.reg_write(0x1234, 0x5678)
+
+    sent = link.dev.write.call_args[0][1]
+    prop, size = struct.unpack("<II", sent[:8])
+    device_id, addr, val = struct.unpack("<III", sent[8:8 + size])
+    assert prop == PROP_REG32 | PROP_WRITE_FLAG
+    assert addr == 0x1234
+    assert val == 0x5678
+
+
+def test_reg_write_field_only_changes_masked_bits():
+    link = _linked_with_mock_dev()
+    with patch.object(link, "reg_read", return_value=0b1111_0000), \
+         patch.object(link, "reg_write") as mock_write:
+        link.reg_write_field(0x1234, data=0b0000_1010, mask=0b0000_1111)
+
+    written_addr, written_val, _device_id = mock_write.call_args[0]
+    assert written_addr == 0x1234
+    assert written_val == 0b1111_1010
+
+
+# ---------------------------------------------------------------------------
+# streaming
+# ---------------------------------------------------------------------------
+
+def test_run_start_writes_expected_number_of_registers():
+    link = _linked_with_mock_dev()
+    with patch.object(link, "reg_write") as mock_write, \
+         patch.object(link, "reg_write_field") as mock_write_field:
+        link.run_start()
+
+    assert mock_write.call_count == 3
+    assert mock_write_field.call_count == 2
+
+
+def test_read_data_returns_bytes_from_data_endpoint():
+    link = _linked_with_mock_dev()
+    link.dev.read.return_value = b"\x01\x02\x03"
+
+    result = link.read_data(size=1024, timeout=500)
+
+    assert result == b"\x01\x02\x03"
+    link.dev.read.assert_called_once_with(link.ep_data.bEndpointAddress, 1024, timeout=500)
+
+
+def test_stream_yields_empty_bytes_on_timeout_then_continues():
+    link = _linked_with_mock_dev()
+    timeout_error = usb.core.USBError("timed out")
+    timeout_error.errno = 60
+    link.dev.read.side_effect = [timeout_error, b"\x01\x02\x03"]
+
+    gen = link.stream()
+
+    assert next(gen) == b""
+    assert next(gen) == b"\x01\x02\x03"
+
+
+def test_stream_reraises_non_timeout_errors():
+    link = _linked_with_mock_dev()
+    error = usb.core.USBError("permission denied")
+    error.errno = 13  # not a recognized timeout errno
+    link.dev.read.side_effect = error
+
+    with pytest.raises(usb.core.USBError):
+        next(link.stream())


### PR DESCRIPTION
usb_link: This module writes a USB driver compatible with the EVK4 camera and additionally gathers raw data from the device.  
decode_video: This scripts converts the EVT3 events into video frames for viewing, stylized to be visible and indicate events with different colors. 
live_view: This script reprocesses and renders a live viewing window to be able to test with the camera. 