### PR TITLE
Refactor/dataset wrapper consistency

### DIFF
--- a/src/evlib/dataloaders/__init__.py
+++ b/src/evlib/dataloaders/__init__.py
@@ -10,6 +10,8 @@ from ._dsec import DSECCamera
 from ._dsec import DSECDataLoader
 from ._dsec import DSECSample
 from ._dsec import DSECSplit
+from ._dsec_rosbag import DSECImuData
+from ._dsec_rosbag import DSECLidarScan
 from ._mvsec import MVSECDataLoader
 from ._mvsec_types import MVSECOdometryData
 from ._storage_common import LoadingType
@@ -25,6 +27,8 @@ __all__ = [
     "DavisRecordingLoader",
     "DSECCamera",
     "DSECDataLoader",
+    "DSECImuData",
+    "DSECLidarScan",
     "DSECSample",
     "DSECSplit",
     "DataLoaderBase",

--- a/src/evlib/datasets/__init__.py
+++ b/src/evlib/datasets/__init__.py
@@ -1,6 +1,7 @@
 """Dataset base classes for event camera datasets."""
 
 from ._base import BlockAccessDataset
+from ._base import BlockDatasetIterator
 from ._base import EventDataset
 from ._base import IteratorAccessDataset
 from ._base import event_sample_collate
@@ -21,6 +22,7 @@ from .mvsec import mvsec_collate_fn
 
 __all__ = [
     "BlockAccessDataset",
+    "BlockDatasetIterator",
     "DSECDataset",
     "DSECIterator",
     "ECDDataset",

--- a/src/evlib/datasets/_base.py
+++ b/src/evlib/datasets/_base.py
@@ -14,13 +14,20 @@ for PyTorch-like DataLoader integration.
 import abc
 from typing import Any
 from typing import Dict
+from typing import Generic
 from typing import List
 from typing import TypeVar
 
 import numpy as np
+from torch.utils.data import get_worker_info
 
 
 EventDatasetT = TypeVar("EventDatasetT", bound="EventDataset")
+BlockDatasetT = TypeVar("BlockDatasetT", bound="BlockAccessDataset")
+BlockDatasetIteratorT = TypeVar(
+    "BlockDatasetIteratorT",
+    bound="BlockDatasetIterator[Any]",
+)
 
 
 def event_sample_collate(batch: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -54,9 +61,11 @@ class EventDataset(abc.ABC):
         """Release resources (file handles, etc.)."""
 
     def __enter__(self: EventDatasetT) -> EventDatasetT:
+        """Return this dataset when entering a context manager."""
         return self
 
     def __exit__(self, *exc: Any) -> None:
+        """Close this dataset when leaving a context manager."""
         self.close()
 
 
@@ -88,8 +97,8 @@ class BlockAccessDataset(EventDataset):
 class IteratorAccessDataset(EventDataset):
     """Iterable style dataset for streaming/online sources.
 
-    Subclasses must implement __iter__ and __next__, each yielding
-    a dict with at least an 'events' key.
+    Subclasses must implement __iter__, which returns an iterator, and
+    __next__, which returns a dict with at least an 'events' key.
     """
 
     @abc.abstractmethod
@@ -101,9 +110,68 @@ class IteratorAccessDataset(EventDataset):
         """Return the next sample dict, or raise class StopIteration."""
 
     def reset(self) -> None:
-        """Reset iteration to the beginning
+        """Reset iteration to the beginning.
 
-        The default implementation raises class NotImplementedError
-        subclasses that support rewinding should override this.
+        The default implementation raises :class:`NotImplementedError`;
+        subclasses that support rewinding should override it.
         """
         raise NotImplementedError("This iterator does not support reset()")
+
+
+class BlockDatasetIterator(IteratorAccessDataset, Generic[BlockDatasetT]):
+    """Sequential cursor over a finite block access dataset.
+
+    Each call to :func:`iter` starts a new pass from the first sample. A partly
+    consumed pass therefore cannot be resumed with a second :func:`iter` call;
+    keep the iterator itself and call :func:`next`, or call :meth:`reset` to
+    rewind deliberately. Closing the iterator closes the wrapped dataset.
+
+    Use the wrapped map style dataset directly with a torch ``DataLoader``
+    when worker processes, shuffling, or sampling are needed. This iterator
+    rejects worker-process iteration because otherwise every worker would
+    repeat the full dataset.
+
+    Args:
+        dataset: Map style dataset to iterate over.
+    """
+
+    def __init__(self, dataset: BlockDatasetT) -> None:
+        """Create an iterator over one map style dataset."""
+        self._dataset = dataset
+        self._current = 0
+
+    @property
+    def dataset(self) -> BlockDatasetT:
+        """Return the wrapped map style dataset."""
+        return self._dataset
+
+    def __iter__(self: BlockDatasetIteratorT) -> BlockDatasetIteratorT:
+        """Return this cursor rewound to the first sample."""
+        if get_worker_info() is not None:
+            raise RuntimeError(
+                "BlockDatasetIterator does not support DataLoader worker processes because "
+                "each worker would repeat the full dataset. Use num_workers=0 or pass the "
+                "wrapped map style dataset to DataLoader."
+            )
+        self._current = 0
+        return self
+
+    def __next__(self) -> dict:
+        """Return the next indexed sample."""
+        num_samples = len(self._dataset)
+        exhausted = self._current >= num_samples
+        if exhausted:
+            raise StopIteration
+
+        current_index = self._current
+        sample = self._dataset[current_index]
+        self._current += 1
+        return sample
+
+    def reset(self) -> None:
+        """Reset the iteration cursor to the first sample."""
+        self._current = 0
+
+    def close(self) -> None:
+        """Release wrapped dataset resources."""
+        self._dataset.close()

--- a/src/evlib/datasets/_base.py
+++ b/src/evlib/datasets/_base.py
@@ -4,6 +4,9 @@
     ├── BlockAccessDataset    - PyTorch map-style (__getitem__, __len__)
     └── IteratorAccessDataset - PyTorch iterable-style (__iter__, __next__)
 
+Each branch also derives from its torch.utils.data counterpart, so concrete
+datasets can be handed to a torch DataLoader directly.
+
 A DataLoader is not a Dataset. Dataset uses a DataLoader via composition.
 DataLoaders live in evlib.dataloaders and provide flexible I/O
 (load_events, time_to_index, etc.) for researchers with custom access
@@ -19,6 +22,8 @@ from typing import List
 from typing import TypeVar
 
 import numpy as np
+from torch.utils.data import Dataset as TorchDataset
+from torch.utils.data import IterableDataset as TorchIterableDataset
 from torch.utils.data import get_worker_info
 
 
@@ -69,7 +74,7 @@ class EventDataset(abc.ABC):
         self.close()
 
 
-class BlockAccessDataset(EventDataset):
+class BlockAccessDataset(EventDataset, TorchDataset):
     """Map style dataset supporting random access by frame index.
 
     PyTorch compatible contract:
@@ -94,11 +99,15 @@ class BlockAccessDataset(EventDataset):
         """Number of frames."""
 
 
-class IteratorAccessDataset(EventDataset):
+class IteratorAccessDataset(EventDataset, TorchIterableDataset):
     """Iterable style dataset for streaming/online sources.
 
     Subclasses must implement __iter__, which returns an iterator, and
     __next__, which returns a dict with at least an 'events' key.
+
+    Subclasses iterate themselves: __iter__ returns the dataset itself.
+    A torch DataLoader calls iter() once per epoch, so __iter__ must
+    start a fresh pass for the dataset to be readable more than once.
     """
 
     @abc.abstractmethod
@@ -121,10 +130,11 @@ class IteratorAccessDataset(EventDataset):
 class BlockDatasetIterator(IteratorAccessDataset, Generic[BlockDatasetT]):
     """Sequential cursor over a finite block access dataset.
 
-    Each call to :func:`iter` starts a new pass from the first sample. A partly
-    consumed pass therefore cannot be resumed with a second :func:`iter` call;
-    keep the iterator itself and call :func:`next`, or call :meth:`reset` to
-    rewind deliberately. Closing the iterator closes the wrapped dataset.
+    Each call to :func:`iter` starts a new pass from the first sample, which is
+    what lets a torch ``DataLoader`` read the sequence again on every epoch. A
+    partly consumed pass therefore cannot be resumed with a second :func:`iter`
+    call; keep the iterator itself and call :func:`next`, or call :meth:`reset`
+    to rewind deliberately. Closing the iterator closes the wrapped dataset.
 
     Use the wrapped map style dataset directly with a torch ``DataLoader``
     when worker processes, shuffling, or sampling are needed. This iterator

--- a/src/evlib/datasets/dsec.py
+++ b/src/evlib/datasets/dsec.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Iterator
 from typing import cast
+
+import numpy as np
+import numpy.typing as npt
 
 from evlib.dataloaders import DSECCamera
 from evlib.dataloaders import DSECDataLoader
+from evlib.dataloaders import DSECImuData
+from evlib.dataloaders import DSECLidarScan
 from evlib.dataloaders import DSECSplit
+from evlib.dataloaders import LoadingType
 from evlib.dataloaders import LoadMode
 from evlib.dataloaders import ResidentLoadMode
+from evlib.types import RawEvents
 
 from ._base import BlockAccessDataset
 from ._base import BlockDatasetIterator
@@ -125,6 +133,243 @@ class DSECDataset(BlockAccessDataset):
             f"split={self.split!r}, "
             f"camera={self.camera!r})"
         )
+
+    def load_events(self, start_index: int, end_index: int) -> RawEvents:
+        """Load events in ``[start_index, end_index)``."""
+        return self._loader.load_events(start_index, end_index)
+
+    @property
+    def num_events(self) -> int:
+        """Total number of events."""
+        return self._loader.num_events
+
+    def time_to_index(self, t: float) -> int:
+        """Find the last event strictly before time ``t``."""
+        return self._loader.time_to_index(t)
+
+    def index_to_time(self, index: int) -> float:
+        """Return the timestamp of one event by index."""
+        return self._loader.index_to_time(index)
+
+    def times_to_indices(self, timestamps: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        """Vectorized form of :meth:`time_to_index`."""
+        return self._loader.times_to_indices(timestamps)
+
+    def indices_to_times(self, indices: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        """Vectorized form of :meth:`index_to_time`."""
+        return self._loader.indices_to_times(indices)
+
+    def get_events_by_time(self, t_start: float, t_end: float) -> RawEvents:
+        """Load events in ``[t_start, t_end)``."""
+        return self._loader.get_events_by_time(t_start, t_end)
+
+    def iter_events(
+        self,
+        num_events: int | None = None,
+        time_window: float | None = None,
+    ) -> Iterator[RawEvents]:
+        """Yield event chunks by count or by time window."""
+        return self._loader.iter_events(num_events=num_events, time_window=time_window)
+
+    @property
+    def event_load_mode(self) -> LoadingType:
+        """Loading mode used for event arrays."""
+        return self._loader.event_load_mode
+
+    @property
+    def t_offset(self) -> np.int64:
+        """Sequence time offset in microseconds."""
+        return self._loader.t_offset
+
+    @property
+    def ms_to_idx(self) -> npt.NDArray[np.int64]:
+        """Millisecond to event index lookup table."""
+        return self._loader.ms_to_idx
+
+    @property
+    def has_rectify_map(self) -> bool:
+        """Whether an event rectification map is loaded."""
+        return self._loader.has_rectify_map
+
+    @property
+    def events_prerectified(self) -> bool:
+        """Whether cached events were rectified during initialization."""
+        return self._loader.events_prerectified
+
+    @property
+    def rectify_map(self) -> npt.NDArray[np.float32] | None:
+        """Event rectification map, or None when not loaded."""
+        return self._loader.rectify_map
+
+    def rectify_events(self, events: RawEvents) -> RawEvents:
+        """Map raw event coordinates onto the rectified image plane."""
+        return self._loader.rectify_events(events)
+
+    @property
+    def has_images(self) -> bool:
+        """Whether rectified images are available."""
+        return self._loader.has_images
+
+    @property
+    def image_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Image timestamps, or None when images are not loaded."""
+        return self._loader.image_timestamps
+
+    @property
+    def image_exposure_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Image exposure timestamps, or None when unavailable."""
+        return self._loader.image_exposure_timestamps
+
+    @property
+    def num_images(self) -> int:
+        """Number of rectified images."""
+        return self._loader.num_images
+
+    def load_image(self, index: int) -> npt.NDArray[np.uint8]:
+        """Load one rectified image by index."""
+        return self._loader.load_image(index)
+
+    def find_nearest_image_index(self, t: float) -> int:
+        """Find the image index nearest to time ``t``."""
+        return self._loader.find_nearest_image_index(t)
+
+    @property
+    def has_flow_forward(self) -> bool:
+        """Whether forward optical flow is available."""
+        return self._loader.has_flow_forward
+
+    @property
+    def has_flow_backward(self) -> bool:
+        """Whether backward optical flow is available."""
+        return self._loader.has_flow_backward
+
+    @property
+    def flow_forward_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Forward flow timestamps, or None when not loaded."""
+        return self._loader.flow_forward_timestamps
+
+    @property
+    def flow_backward_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Backward flow timestamps, or None when not loaded."""
+        return self._loader.flow_backward_timestamps
+
+    @property
+    def num_flow_forward(self) -> int:
+        """Number of forward optical flow frames."""
+        return self._loader.num_flow_forward
+
+    @property
+    def num_flow_backward(self) -> int:
+        """Number of backward optical flow frames."""
+        return self._loader.num_flow_backward
+
+    def load_flow_forward(
+        self, index: int
+    ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
+        """Load one forward flow frame and its validity mask."""
+        return self._loader.load_flow_forward(index)
+
+    def load_flow_backward(
+        self, index: int
+    ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
+        """Load one backward flow frame and its validity mask."""
+        return self._loader.load_flow_backward(index)
+
+    @property
+    def has_disparity(self) -> bool:
+        """Whether disparity maps are available."""
+        return self._loader.has_disparity
+
+    @property
+    def disparity_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Disparity timestamps, or None when not loaded."""
+        return self._loader.disparity_timestamps
+
+    @property
+    def num_disparity_frames(self) -> int:
+        """Number of disparity frames."""
+        return self._loader.num_disparity_frames
+
+    def load_disparity(self, index: int) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.bool_]]:
+        """Load one disparity map and its validity mask."""
+        return self._loader.load_disparity(index)
+
+    @property
+    def has_imu(self) -> bool:
+        """Whether IMU samples are available."""
+        return self._loader.has_imu
+
+    @property
+    def imu_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """IMU timestamps, or None when not loaded."""
+        return self._loader.imu_timestamps
+
+    @property
+    def imu_data(self) -> DSECImuData | None:
+        """Resident IMU measurements, or None when not loaded."""
+        return self._loader.imu_data
+
+    @property
+    def num_imu_samples(self) -> int:
+        """Number of IMU samples."""
+        return self._loader.num_imu_samples
+
+    def load_imu(self, t_start: float, t_end: float) -> DSECImuData:
+        """Load IMU measurements in ``[t_start, t_end)``."""
+        return self._loader.load_imu(t_start, t_end)
+
+    @property
+    def has_lidar(self) -> bool:
+        """Whether lidar scans are available."""
+        return self._loader.has_lidar
+
+    @property
+    def lidar_timestamps(self) -> npt.NDArray[np.float64] | None:
+        """Lidar scan timestamps, or None when not loaded."""
+        return self._loader.lidar_timestamps
+
+    @property
+    def num_lidar_scans(self) -> int:
+        """Number of lidar scans."""
+        return self._loader.num_lidar_scans
+
+    @property
+    def lidar_frame_id(self) -> str | None:
+        """Lidar coordinate frame identifier, or None when unavailable."""
+        return self._loader.lidar_frame_id
+
+    def load_lidar(self, index: int) -> DSECLidarScan:
+        """Load one lidar scan by index."""
+        return self._loader.load_lidar(index)
+
+    def load_lidar_by_time(self, t_start: float, t_end: float) -> list[DSECLidarScan]:
+        """Load lidar scans in ``[t_start, t_end)``."""
+        return self._loader.load_lidar_by_time(t_start, t_end)
+
+    @property
+    def has_calibration(self) -> bool:
+        """Whether camera calibration is loaded."""
+        return self._loader.has_calibration
+
+    @property
+    def calibration(self) -> dict[str, Any] | None:
+        """Camera calibration, or None when not loaded."""
+        return self._loader.calibration
+
+    @property
+    def cam_to_lidar_calibration(self) -> dict[str, Any] | None:
+        """Camera to lidar extrinsics, or None when not loaded."""
+        return self._loader.cam_to_lidar_calibration
+
+    @property
+    def cam_to_imu_calibration(self) -> dict[str, Any] | None:
+        """Camera to IMU extrinsics, or None when not loaded."""
+        return self._loader.cam_to_imu_calibration
+
+    @property
+    def imu_calibration(self) -> dict[str, Any] | None:
+        """IMU intrinsics, or None when not loaded."""
+        return self._loader.imu_calibration
 
 
 class DSECIterator(BlockDatasetIterator[DSECDataset]):

--- a/src/evlib/datasets/dsec.py
+++ b/src/evlib/datasets/dsec.py
@@ -12,7 +12,7 @@ from evlib.dataloaders import LoadMode
 from evlib.dataloaders import ResidentLoadMode
 
 from ._base import BlockAccessDataset
-from ._base import IteratorAccessDataset
+from ._base import BlockDatasetIterator
 from ._base import event_sample_collate
 
 
@@ -127,7 +127,7 @@ class DSECDataset(BlockAccessDataset):
         )
 
 
-class DSECIterator(IteratorAccessDataset):
+class DSECIterator(BlockDatasetIterator[DSECDataset]):
     """Streaming iterator over one DSEC sequence.
 
     Args:
@@ -138,13 +138,7 @@ class DSECIterator(IteratorAccessDataset):
 
     def __init__(self, root: str, sequence: str, **kwargs: Any) -> None:
         """Initialize an iterator over one DSEC sequence."""
-        self._dataset = DSECDataset(root, sequence, **kwargs)
-        self._current = 0
-
-    @property
-    def dataset(self) -> DSECDataset:
-        """Return the underlying map-style dataset."""
-        return self._dataset
+        super().__init__(DSECDataset(root, sequence, **kwargs))
 
     @property
     def root(self) -> str:
@@ -165,29 +159,6 @@ class DSECIterator(IteratorAccessDataset):
     def camera(self) -> DSECCamera:
         """Return the selected event camera stream: ``"left"`` or ``"right"``."""
         return self._dataset.camera
-
-    def __iter__(self) -> DSECIterator:
-        """Return the iterator reset to the first sample."""
-        self._current = 0
-        return self
-
-    def __next__(self) -> dict:
-        """Return the next synchronized sample."""
-        if self._current >= len(self._dataset):
-            raise StopIteration
-
-        current_index = self._current
-        sample = self._dataset[current_index]
-        self._current += 1
-        return sample
-
-    def reset(self) -> None:
-        """Reset the iteration cursor to the first sample."""
-        self._current = 0
-
-    def close(self) -> None:
-        """Release wrapped dataset resources."""
-        self._dataset.close()
 
     def __repr__(self) -> str:
         """Return a concise iterator representation."""

--- a/src/evlib/datasets/ecd.py
+++ b/src/evlib/datasets/ecd.py
@@ -40,7 +40,7 @@ from evlib.dataloaders import ResidentLoadMode
 from evlib.types import RawEvents
 
 from ._base import BlockAccessDataset
-from ._base import IteratorAccessDataset
+from ._base import BlockDatasetIterator
 from ._base import event_sample_collate
 
 
@@ -502,7 +502,7 @@ class ECDDataset(BlockAccessDataset):
         return self._loader.load_depth(depth_index)
 
 
-class ECDIterator(IteratorAccessDataset):
+class ECDIterator(BlockDatasetIterator[ECDDataset]):
     """Streaming iterator over an ECD sequence.
 
     Yields the same dicts as :meth:`ECDDataset.__getitem__`, frame by frame.
@@ -515,13 +515,7 @@ class ECDIterator(IteratorAccessDataset):
 
     def __init__(self, root: str, sequence: str, **kwargs: Any) -> None:
         """Initialize an iterator over one ECD sequence."""
-        self._dataset = ECDDataset(root, sequence, **kwargs)
-        self._current = 0
-
-    @property
-    def dataset(self) -> ECDDataset:
-        """Underlying map style ECD dataset."""
-        return self._dataset
+        super().__init__(ECDDataset(root, sequence, **kwargs))
 
     @property
     def root(self) -> str:
@@ -537,30 +531,6 @@ class ECDIterator(IteratorAccessDataset):
     def camera_model(self) -> str:
         """Camera model for real ECD DAVIS sequences."""
         return self._dataset.camera_model
-
-    def __iter__(self) -> ECDIterator:
-        """Return the iterator reset to the first frame."""
-        self._current = 0
-        return self
-
-    def __next__(self) -> dict:
-        """Return the next frame indexed sample."""
-        dataset_length = len(self._dataset)
-        if self._current >= dataset_length:
-            raise StopIteration
-
-        current_index = self._current
-        sample = self._dataset[current_index]
-        self._current += 1
-        return sample
-
-    def reset(self) -> None:
-        """Reset iteration cursor to the beginning."""
-        self._current = 0
-
-    def close(self) -> None:
-        """Release wrapped dataset resources."""
-        self._dataset.close()
 
     def __repr__(self) -> str:
         """Return a concise iterator representation."""

--- a/src/evlib/datasets/mvsec.py
+++ b/src/evlib/datasets/mvsec.py
@@ -36,7 +36,7 @@ from evlib.dataloaders import ResidentLoadMode
 from evlib.types import RawEvents
 
 from ._base import BlockAccessDataset
-from ._base import IteratorAccessDataset
+from ._base import BlockDatasetIterator
 from ._base import event_sample_collate
 
 
@@ -48,7 +48,7 @@ class MVSECDataset(BlockAccessDataset):
 
     Thin wrapper around class MVSECDataLoader that adds a frame indexed __getitem__ / __len__ contract suitable for PyTorch DataLoader integration.
 
-    For custom access patterns (overlapping windows, multi-scale pyramids, arbitrary time slicing), use the attr loader directly
+    For custom access patterns (overlapping windows, multiscale pyramids, arbitrary time slicing), use the attr loader directly
 
         ds = MVSECDataset(root, "indoor_flying1")
         loader = ds.loader
@@ -211,6 +211,11 @@ class MVSECDataset(BlockAccessDataset):
     def has_gt_flow(self) -> bool:
         """Whether ground truth optical flow is available."""
         return self._loader.has_gt_flow
+
+    @property
+    def valid_frame_range(self) -> Optional[Tuple[int, Optional[int]]]:
+        """Valid GT flow frame index range for this sequence, if known."""
+        return self._loader.valid_frame_range
 
     def load_optical_flow(self, t1: float, t2: float) -> npt.NDArray[np.float32]:
         """Load ground truth optical flow between two timestamps."""
@@ -495,7 +500,7 @@ class MVSECDataset(BlockAccessDataset):
         return self._loader.load_velodyne_scan(scan_index)
 
 
-class MVSECIterator(IteratorAccessDataset):
+class MVSECIterator(BlockDatasetIterator[MVSECDataset]):
     """Streaming iterator over MVSEC frames.
 
     Yields the same dicts as :meth:`MVSECDataset.__getitem__`, frame by frame.
@@ -507,8 +512,7 @@ class MVSECIterator(IteratorAccessDataset):
     """
 
     def __init__(self, root: str, sequence: str, **kwargs: Any) -> None:
-        self._dataset = MVSECDataset(root, sequence, **kwargs)
-        self._current = 0
+        super().__init__(MVSECDataset(root, sequence, **kwargs))
 
     @property
     def root(self) -> str:
@@ -522,24 +526,6 @@ class MVSECIterator(IteratorAccessDataset):
     def camera(self) -> str:
         return self._dataset.camera
 
-    def __iter__(self) -> "MVSECIterator":
-        self._current = 0
-        return self
-
-    def __next__(self) -> dict:
-        dataset_length = len(self._dataset)
-        exhausted = self._current >= dataset_length
-        if exhausted:
-            raise StopIteration
-        current_index = self._current
-        sample = self._dataset[current_index]
-        self._current += 1
-        return sample
-
-    def reset(self) -> None:
-        """Reset iteration cursor to the beginning."""
-        self._current = 0
-
     def __repr__(self) -> str:
         return (
             f"{type(self).__name__}("
@@ -547,6 +533,3 @@ class MVSECIterator(IteratorAccessDataset):
             f"sequence={self.sequence!r}, "
             f"camera={self.camera!r})"
         )
-
-    def close(self) -> None:
-        self._dataset.close()

--- a/src/evlib/datasets/mvsec.py
+++ b/src/evlib/datasets/mvsec.py
@@ -46,9 +46,11 @@ mvsec_collate_fn = event_sample_collate
 class MVSECDataset(BlockAccessDataset):
     """MVSEC dataset (block access / map style).
 
-    Thin wrapper around class MVSECDataLoader that adds a frame indexed __getitem__ / __len__ contract suitable for PyTorch DataLoader integration.
+    Thin wrapper around class MVSECDataLoader that adds a frame indexed
+    __getitem__ / __len__ contract suitable for PyTorch DataLoader integration.
 
-    For custom access patterns (overlapping windows, multiscale pyramids, arbitrary time slicing), use the attr loader directly
+    For custom access patterns (overlapping windows, multiscale pyramids,
+    arbitrary time slicing), use the attr loader directly
 
         ds = MVSECDataset(root, "indoor_flying1")
         loader = ds.loader
@@ -99,6 +101,7 @@ class MVSECDataset(BlockAccessDataset):
         image_load_mode: ResidentLoadMode = "cached",
         cache_dir: Optional[str] = None,
     ) -> None:
+        """Initialize a map style dataset for one MVSEC sequence."""
         self._loader = MVSECDataLoader(
             root,
             sequence,
@@ -128,14 +131,17 @@ class MVSECDataset(BlockAccessDataset):
 
     @property
     def root(self) -> str:
+        """Return the dataset root passed to the loader."""
         return self._loader.root
 
     @property
     def sequence(self) -> str:
+        """Return the MVSEC sequence name."""
         return self._loader.sequence
 
     @property
     def camera(self) -> str:
+        """Return the selected event camera stream."""
         return self._loader.camera
 
     # BlockAccessDataset contract (PyTorch style)
@@ -149,9 +155,11 @@ class MVSECDataset(BlockAccessDataset):
         return self.num_frames
 
     def close(self) -> None:
+        """Release loader resources."""
         self._loader.close()
 
     def __repr__(self) -> str:
+        """Return a concise dataset representation."""
         return (
             f"{type(self).__name__}("
             f"root={self.root!r}, "
@@ -160,7 +168,8 @@ class MVSECDataset(BlockAccessDataset):
         )
 
     # Convenience delegations to loader.
-    # sections below expose selected loader APIs directly on the dataset so callers can use ds.load_events(...) without reaching through ds.loader.
+    # The sections below expose selected loader APIs directly on the dataset so
+    # callers can use ds.load_events(...) without reaching through ds.loader.
 
     def load_events(self, start_index: int, end_index: int) -> RawEvents:
         """Load events in [start_index, end_index)."""
@@ -508,25 +517,30 @@ class MVSECIterator(BlockDatasetIterator[MVSECDataset]):
     Args:
         root: Directory containing the MVSEC files.
         sequence: Sequence name.
-        **kwargs: Forwarded to class MVSECDataset.
+        ``**kwargs``: Forwarded to :class:`MVSECDataset`.
     """
 
     def __init__(self, root: str, sequence: str, **kwargs: Any) -> None:
+        """Initialize an iterator over one MVSEC sequence."""
         super().__init__(MVSECDataset(root, sequence, **kwargs))
 
     @property
     def root(self) -> str:
+        """Return the dataset root passed to the loader."""
         return self._dataset.root
 
     @property
     def sequence(self) -> str:
+        """Return the MVSEC sequence name."""
         return self._dataset.sequence
 
     @property
     def camera(self) -> str:
+        """Return the selected event camera stream."""
         return self._dataset.camera
 
     def __repr__(self) -> str:
+        """Return a concise iterator representation."""
         return (
             f"{type(self).__name__}("
             f"root={self.root!r}, "

--- a/tests/datasets/test_base.py
+++ b/tests/datasets/test_base.py
@@ -1,11 +1,18 @@
 """Tests for dataset base classes."""
 
 import pytest
+from torch.utils.data import DataLoader
+from torch.utils.data import Dataset as TorchDataset
+from torch.utils.data import IterableDataset as TorchIterableDataset
 
 from evlib.datasets._base import BlockAccessDataset
 from evlib.datasets._base import BlockDatasetIterator
 from evlib.datasets._base import EventDataset
 from evlib.datasets._base import IteratorAccessDataset
+
+
+def _events_only(batch: list) -> list:
+    return [sample["events"] for sample in batch]
 
 
 class _DummyEventDataset(EventDataset):
@@ -73,6 +80,10 @@ class TestDatasetBaseClasses:  # noqa: D101
         with pytest.raises(StopIteration):
             next(ds)
 
+    def test_base_classes_have_expected_torch_types(self) -> None:  # noqa: D102
+        assert isinstance(_DummyBlockDataset(), TorchDataset)
+        assert isinstance(_DummyIteratorDataset(), TorchIterableDataset)
+
     def test_reset_default_raises(self) -> None:  # noqa: D102
         ds = _DummyIteratorDataset()
         with pytest.raises(NotImplementedError):
@@ -85,6 +96,11 @@ class TestDatasetBaseClasses:  # noqa: D101
             BlockAccessDataset()  # type: ignore[abstract]
         with pytest.raises(TypeError):
             IteratorAccessDataset()  # type: ignore[abstract]
+
+    def test_block_access_dataset_feeds_torch_dataloader(self) -> None:  # noqa: D102
+        loader = DataLoader(_DummyBlockDataset(), batch_size=2, collate_fn=_events_only)
+        expected_batches = [[0, 1], [2]]
+        assert list(loader) == expected_batches
 
 
 class TestBlockDatasetIterator:  # noqa: D101
@@ -149,3 +165,13 @@ class TestBlockDatasetIterator:  # noqa: D101
         with BlockDatasetIterator(dataset) as iterator:
             assert next(iterator) == {"events": 0}
         assert dataset.closed is True
+
+    def test_torch_dataloader_rereads_every_epoch(self) -> None:  # noqa: D102
+        iterator = BlockDatasetIterator(_DummyBlockDataset())
+        loader = DataLoader(iterator, batch_size=2, collate_fn=_events_only)
+        expected_batches = [[0, 1], [2]]
+
+        first_epoch = list(loader)
+        second_epoch = list(loader)
+
+        assert first_epoch == second_epoch == expected_batches

--- a/tests/datasets/test_base.py
+++ b/tests/datasets/test_base.py
@@ -3,6 +3,7 @@
 import pytest
 
 from evlib.datasets._base import BlockAccessDataset
+from evlib.datasets._base import BlockDatasetIterator
 from evlib.datasets._base import EventDataset
 from evlib.datasets._base import IteratorAccessDataset
 
@@ -16,14 +17,15 @@ class _DummyEventDataset(EventDataset):
 
 
 class _DummyBlockDataset(BlockAccessDataset):
-    def __init__(self) -> None:
+    def __init__(self, num_samples: int = 3) -> None:
         self.closed = False
+        self._num_samples = num_samples
 
     def __getitem__(self, index: int) -> dict:
         return {"events": index}
 
     def __len__(self) -> int:
-        return 3
+        return self._num_samples
 
     def close(self) -> None:
         self.closed = True
@@ -49,21 +51,21 @@ class _DummyIteratorDataset(IteratorAccessDataset):
         self.closed = True
 
 
-class TestDatasetBaseClasses:
-    def test_event_dataset_context_manager_closes(self) -> None:
+class TestDatasetBaseClasses:  # noqa: D101
+    def test_event_dataset_context_manager_closes(self) -> None:  # noqa: D102
         ds = _DummyEventDataset()
         with ds:
             assert ds.closed is False
         assert ds.closed is True
 
-    def test_block_access_dataset_contract(self) -> None:
+    def test_block_access_dataset_contract(self) -> None:  # noqa: D102
         ds = _DummyBlockDataset()
         sample = ds[0]
         expected_sample = {"events": 0}
         assert len(ds) == 3
         assert sample == expected_sample
 
-    def test_iterator_access_dataset_contract(self) -> None:
+    def test_iterator_access_dataset_contract(self) -> None:  # noqa: D102
         ds = _DummyIteratorDataset()
         samples = list(ds)
         expected_samples = [{"events": 0}, {"events": 1}]
@@ -71,15 +73,79 @@ class TestDatasetBaseClasses:
         with pytest.raises(StopIteration):
             next(ds)
 
-    def test_reset_default_raises(self) -> None:
+    def test_reset_default_raises(self) -> None:  # noqa: D102
         ds = _DummyIteratorDataset()
         with pytest.raises(NotImplementedError):
             ds.reset()
 
-    def test_abstract_base_cannot_be_instantiated(self) -> None:
+    def test_abstract_base_cannot_be_instantiated(self) -> None:  # noqa: D102
         with pytest.raises(TypeError):
             EventDataset()  # type: ignore[abstract]
         with pytest.raises(TypeError):
             BlockAccessDataset()  # type: ignore[abstract]
         with pytest.raises(TypeError):
             IteratorAccessDataset()  # type: ignore[abstract]
+
+
+class TestBlockDatasetIterator:  # noqa: D101
+    def test_yields_every_sample_in_order(self) -> None:  # noqa: D102
+        iterator = BlockDatasetIterator(_DummyBlockDataset())
+        expected_samples = [{"events": 0}, {"events": 1}, {"events": 2}]
+        assert list(iterator) == expected_samples
+
+    def test_exhausted_iterator_raises_stop_iteration(self) -> None:  # noqa: D102
+        iterator = BlockDatasetIterator(_DummyBlockDataset())
+        for _ in iterator:
+            pass
+        with pytest.raises(StopIteration):
+            next(iterator)
+
+    def test_empty_dataset_stops_immediately(self) -> None:  # noqa: D102
+        iterator = BlockDatasetIterator(_DummyBlockDataset(num_samples=0))
+        assert list(iterator) == []
+
+    def test_reset_replays_from_first_sample(self) -> None:  # noqa: D102
+        iterator = BlockDatasetIterator(_DummyBlockDataset())
+        first_sample = next(iterator)
+        next(iterator)
+
+        iterator.reset()
+        replayed_sample = next(iterator)
+
+        assert first_sample == replayed_sample == {"events": 0}
+
+    def test_iter_starts_a_new_pass(self) -> None:  # noqa: D102
+        iterator = BlockDatasetIterator(_DummyBlockDataset())
+        next(iterator)
+        next(iterator)
+
+        restarted_sample = next(iter(iterator))
+
+        assert restarted_sample == {"events": 0}
+
+    def test_worker_process_iteration_raises(  # noqa: D102
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("evlib.datasets._base.get_worker_info", object)
+        iterator = BlockDatasetIterator(_DummyBlockDataset())
+
+        with pytest.raises(RuntimeError, match="each worker would repeat the full dataset"):
+            iter(iterator)
+
+    def test_dataset_property_exposes_wrapped_dataset(self) -> None:  # noqa: D102
+        dataset = _DummyBlockDataset()
+        assert BlockDatasetIterator(dataset).dataset is dataset
+
+    def test_close_closes_wrapped_dataset(self) -> None:  # noqa: D102
+        dataset = _DummyBlockDataset()
+        iterator = BlockDatasetIterator(dataset)
+
+        iterator.close()
+
+        assert dataset.closed is True
+
+    def test_context_manager_closes_wrapped_dataset(self) -> None:  # noqa: D102
+        dataset = _DummyBlockDataset()
+        with BlockDatasetIterator(dataset) as iterator:
+            assert next(iterator) == {"events": 0}
+        assert dataset.closed is True

--- a/tests/datasets/test_dsec.py
+++ b/tests/datasets/test_dsec.py
@@ -72,6 +72,76 @@ class TestDSECDataset:
             assert "train" in text
             assert "left" in text
 
+    def test_event_helpers_delegate_to_loader(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(str(dsec_dir), SEQ, load_images=True) as dataset:
+            loader = dataset.loader
+            window_start = dataset.index_to_time(0)
+            window_end = dataset.index_to_time(5)
+
+            assert dataset.num_events == loader.num_events
+            assert dataset.event_load_mode == loader.event_load_mode
+            assert len(dataset.load_events(0, 10)) == 10
+            assert dataset.time_to_index(window_end) == loader.time_to_index(window_end)
+            np.testing.assert_array_equal(
+                dataset.get_events_by_time(window_start, window_end).x,
+                loader.get_events_by_time(window_start, window_end).x,
+            )
+            np.testing.assert_array_equal(
+                dataset.times_to_indices(np.array([window_start, window_end])),
+                loader.times_to_indices(np.array([window_start, window_end])),
+            )
+            np.testing.assert_array_equal(
+                dataset.indices_to_times(np.array([0, 5])),
+                loader.indices_to_times(np.array([0, 5])),
+            )
+
+    def test_modality_delegations_match_loader(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(
+            str(dsec_dir),
+            SEQ,
+            load_images=True,
+            load_flow_forward=True,
+            load_disparity=True,
+        ) as dataset:
+            loader = dataset.loader
+
+            assert dataset.has_images == loader.has_images
+            assert dataset.num_images == loader.num_images
+            assert dataset.has_flow_forward == loader.has_flow_forward
+            assert dataset.num_flow_forward == loader.num_flow_forward
+            assert dataset.has_disparity == loader.has_disparity
+            assert dataset.num_disparity_frames == loader.num_disparity_frames
+            assert dataset.has_calibration == loader.has_calibration
+            assert dataset.has_rectify_map == loader.has_rectify_map
+            assert dataset.events_prerectified == loader.events_prerectified
+            assert dataset.find_nearest_image_index(0.0) == loader.find_nearest_image_index(0.0)
+            np.testing.assert_array_equal(dataset.load_image(0), loader.load_image(0))
+
+            dataset_flow, dataset_valid = dataset.load_flow_forward(0)
+            loader_flow, loader_valid = loader.load_flow_forward(0)
+            np.testing.assert_array_equal(dataset_flow, loader_flow)
+            np.testing.assert_array_equal(dataset_valid, loader_valid)
+
+    def test_rectify_events_delegates_to_loader(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(str(dsec_dir), SEQ, load_images=True, load_rectify_map=True) as dataset:
+            raw_events = dataset.load_events(0, 10)
+
+            rectified = dataset.rectify_events(raw_events)
+            expected = dataset.loader.rectify_events(raw_events)
+
+            np.testing.assert_array_equal(rectified.x, expected.x)
+            np.testing.assert_array_equal(rectified.y, expected.y)
+
+    def test_optional_modalities_absent_without_loading(self, dsec_dir: Path) -> None:  # noqa: D102
+        with DSECDataset(str(dsec_dir), SEQ, load_images=True) as dataset:
+            assert dataset.has_imu is False
+            assert dataset.has_lidar is False
+            assert dataset.imu_timestamps is None
+            assert dataset.lidar_timestamps is None
+            assert dataset.num_imu_samples == 0
+            assert dataset.num_lidar_scans == 0
+            assert dataset.calibration is None
+
 
 class TestDSECIterator:
     """Tests for iterable DSEC dataset access."""

--- a/tests/datasets/test_mvsec.py
+++ b/tests/datasets/test_mvsec.py
@@ -323,6 +323,7 @@ class TestMVSECDataset:
         with MVSECDataset(str(mvsec_dir), SEQ) as ds:
             assert ds.num_frames == N_FRAMES
             assert len(ds) == N_FRAMES
+            assert ds.valid_frame_range == ds.loader.valid_frame_range == (60, 1340)
             frame_timestamps = ds.frame_timestamps
             frame_event_indices = ds.frame_event_indices
             assert frame_timestamps is not None


### PR DESCRIPTION
### Summary

  - Replace duplicated dataset iterator logic with a shared BlockDatasetIterator
  - Make dataset base classes proper PyTorch Dataset and IterableDataset types
  - Align DSECDataset with the ECD and MVSEC wrapper APIs
  - Expose MVSEC’s valid frame range