### PR TITLE
Add data loading guide and runnable dataset examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /dist/
 /docs/_build/
 /docs/_autosummary/
+/outputs/
 /src/*.egg-info/
 __pycache__/
 

--- a/docs/data_loading.md
+++ b/docs/data_loading.md
@@ -1,0 +1,97 @@
+# Loading event data
+
+`evlib.datasets` provides frame-aligned datasets for PyTorch.
+`evlib.dataloaders` provides low-level readers for arbitrary event windows. Use
+`torch.utils.data.DataLoader` to batch a dataset.
+
+## PyTorch datasets
+
+Map-style datasets support indexed access, shuffling, sampling, and worker
+processes. Each sample is a dictionary containing `RawEvents`, timestamps, and
+requested aligned data.
+
+```python
+from torch.utils.data import DataLoader
+
+from evlib.datasets import DSECDataset
+from evlib.datasets import dsec_collate_fn
+
+with DSECDataset(
+    "/data/DSEC",
+    "zurich_city_01_a",
+    camera="left",
+    load_images="lazy",
+    load_flow_forward="lazy",
+) as dataset:
+    loader = DataLoader(
+        dataset,
+        batch_size=4,
+        num_workers=2,
+        collate_fn=dsec_collate_fn,
+    )
+    batch = next(iter(loader))
+```
+
+The collate functions stack `timestamp` as a NumPy array and keep other fields
+as lists, including variable-length events and `None` values. Apply
+task-specific preprocessing after loading.
+
+`ECDDataset` and `MVSECDataset` use the same interface and provide
+`ecd_collate_fn` and `mvsec_collate_fn`.
+
+## Loading modes
+
+Optional modalities use a shared loading convention:
+
+| Value              | Behavior                   |
+| ------------------ | -------------------------- |
+| `False`            | Do not load it.            |
+| `True` or `"lazy"` | Load it when requested.    |
+| `"cached"`         | Load it at initialization. |
+
+Use lazy loading for exploration or worker-based access. Use cached loading for
+repeated passes when the data fits in memory.
+
+## Arbitrary event windows
+
+Use a reader for windows that do not follow frame boundaries:
+
+```python
+from evlib.dataloaders import MVSECDataLoader
+
+with MVSECDataLoader(
+    "/data/MVSEC/indoor_flying",
+    "indoor_flying1",
+    event_load_mode="lazy",
+) as reader:
+    packet = reader.load_events(0, 30_000)
+    start = reader.index_to_time(0)
+    window = reader.get_events_by_time(start, start + 0.02)
+```
+
+Index and time ranges are half-open: `[start, end)`. `RawEvents` exposes `x`,
+`y`, `timestamp`, and `polarity` arrays. `RawEvents.as_numpy()` returns an
+array of shape `(N, 4)` with columns `[y, x, t, p]`.
+
+## Sequential iteration
+
+`ECDIterator`, `DSECIterator`, and `MVSECIterator` iterate through frame-aligned
+samples in sequence order:
+
+```python
+from evlib.datasets import ECDIterator
+
+with ECDIterator("/data/ECD/datasets/davis", "shapes_rotation") as stream:
+    for sample in stream:
+        events = sample["events"]
+```
+
+These iterators do not shard across worker processes. Use `num_workers=0` with
+a PyTorch `DataLoader`, or pass the map-style dataset directly when using
+workers or shuffling.
+
+Use datasets and readers as context managers to close file handles. See the
+[`examples` directory][examples] for runnable workflows and the
+[API reference](./reference.md) for all options.
+
+[examples]: https://github.com/shiba24/event-vision-library/tree/main/examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ maxdepth: 1
 ---
 
 usage
+data_loading
 reference
 contributing
 Code of Conduct <codeofconduct>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,8 @@ The supported python versions are 3.8, 3.9, 3.10, 3.11, and 3.12.
 
 ## Examples
 
-In the github, we have [some examples](https://github.com/shiba24/event-vision-library/tree/main/examples)
+See the [event-data loading guide](./data_loading.md) and the repository's
+[runnable examples](https://github.com/shiba24/event-vision-library/tree/main/examples).
 
 ## API References
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,38 @@
+# Data loading examples
+
+This directory contains examples for loading DSEC, ECD/DAVIS, and MVSEC
+recordings. Each script prints a summary and saves a visualization.
+
+`evlib.datasets` provides frame-aligned PyTorch datasets. `evlib.dataloaders`
+provides low-level readers for custom event windows.
+
+| Example                            | Demonstrates                                     |
+| ---------------------------------- | ------------------------------------------------ |
+| `datasets/dsec_flow_batch.py`      | DSEC optical-flow samples and PyTorch batching   |
+| `datasets/ecd_frame_activity.py`   | Event activity across ECD frame intervals        |
+| `readers/ecd_event_count_image.py` | A fixed-count ECD packet and event count image   |
+| `readers/mvsec_event_windows.py`   | Fixed-count and flow-aligned MVSEC event windows |
+
+## Run the examples
+
+```console
+python examples/datasets/dsec_flow_batch.py \
+    /path/to/DSEC zurich_city_01_a
+
+python examples/datasets/ecd_frame_activity.py \
+    /path/to/ECD/datasets/davis shapes_rotation
+
+python examples/readers/ecd_event_count_image.py \
+    /path/to/ECD/datasets/davis/shapes_rotation
+
+python examples/readers/mvsec_event_windows.py \
+    /path/to/MVSEC/indoor_flying indoor_flying1
+```
+
+The scripts save figures under `outputs/`. Use `--output` to change the path.
+Other settings are constants near the top of each script. The ECD count-image
+example accepts `--sensor-resolution HEIGHT WIDTH` for recordings without frames.
+The MVSEC example requires the sequence's data and ground-truth HDF5 files.
+
+The examples cover data loading and visual checks, not model training or
+evaluation.

--- a/examples/datasets/dsec_flow_batch.py
+++ b/examples/datasets/dsec_flow_batch.py
@@ -1,0 +1,109 @@
+r"""Load and inspect a batch of synchronized DSEC optical-flow samples.
+
+Run:
+    python examples/datasets/dsec_flow_batch.py \
+        /data/DSEC zurich_city_01_a
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from torch.utils.data import DataLoader
+
+from evlib.datasets import DSECDataset
+from evlib.datasets import dsec_collate_fn
+from evlib.vis.view2d import events as render_events
+from evlib.vis.view2d import optical_flow as render_flow
+
+
+BATCH_SIZE = 4
+NUM_WORKERS = 2
+OUTPUT_PATH = Path("outputs/dsec_flow_batch.png")
+
+
+def get_args_parser() -> argparse.ArgumentParser:
+    """Create the argument parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("root", help="DSEC dataset root.")
+    parser.add_argument("sequence", help="DSEC sequence name.")
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH, help="Figure output path.")
+    return parser
+
+
+def flow_to_image(flow: np.ndarray, valid: np.ndarray) -> np.ndarray:
+    """Render optical flow as an RGB image."""
+    valid_flow = np.where(valid[..., None], flow, 0.0)
+    image, _ = render_flow(
+        valid_flow[..., 1],
+        valid_flow[..., 0],
+        visualize_color_wheel=False,
+    )
+    return np.asarray(image)
+
+
+def main() -> None:
+    """Run the DSEC batching example."""
+    args = get_args_parser().parse_args()
+
+    with DSECDataset(
+        args.root,
+        args.sequence,
+        split="train",
+        camera="left",
+        load_images="lazy",
+        load_flow_forward="lazy",
+        load_rectify_map=False,
+        event_load_mode="lazy",
+    ) as dataset:
+        loader = DataLoader(
+            dataset,
+            batch_size=BATCH_SIZE,
+            shuffle=False,
+            num_workers=NUM_WORKERS,
+            collate_fn=dsec_collate_fn,
+        )
+        batch = next(iter(loader))
+
+        events = batch["events"][0]
+        image = batch["image_start"][0]
+        flow_sample = batch["flow"][0]
+        if len(events) == 0:
+            raise RuntimeError("The first DSEC sample contains no events.")
+        if image is None or flow_sample is None:
+            raise RuntimeError("The DSEC sequence does not contain images and flow.")
+        flow, valid = flow_sample
+        start, end = batch["timestamp"][0]
+        event_counts = [len(sample_events) for sample_events in batch["events"]]
+
+        print(
+            f"{dataset.sequence} ({dataset.camera}): "
+            f"{len(dataset):,} samples, {dataset.num_events:,} events"
+        )
+        print(f"batch size: {len(event_counts)}, event counts: {event_counts}")
+
+        fig, (events_axis, image_axis, flow_axis) = plt.subplots(1, 3, figsize=(13.2, 3.8))
+        events_axis.imshow(render_events(events.as_numpy(), dataset.EVENT_SHAPE))
+        events_axis.set_title(f"raw events (distorted), {end - start:.3f} s")
+        image_axis.imshow(image, cmap="gray")
+        image_axis.set_title("start image (rectified)")
+        flow_axis.imshow(flow_to_image(flow, valid))
+        flow_axis.set_title("forward flow (rectified view)")
+        for axis in (events_axis, image_axis, flow_axis):
+            axis.axis("off")
+
+        fig.tight_layout()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(args.output, dpi=140)
+        plt.close(fig)
+        print(f"saved {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/datasets/ecd_frame_activity.py
+++ b/examples/datasets/ecd_frame_activity.py
@@ -1,0 +1,88 @@
+r"""Plot event activity across ECD frame intervals.
+
+Run:
+    python examples/datasets/ecd_frame_activity.py \
+        /data/ECD/datasets/davis shapes_rotation
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from evlib.datasets import ECDIterator
+
+
+MAX_SAMPLES = 200
+OUTPUT_PATH = Path("outputs/ecd_frame_activity.png")
+
+
+def get_args_parser() -> argparse.ArgumentParser:
+    """Create the argument parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("root", help="ECD dataset root.")
+    parser.add_argument("sequence", help="ECD sequence name.")
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH, help="Figure output path.")
+    return parser
+
+
+def main() -> None:
+    """Run the ECD frame-activity example."""
+    args = get_args_parser().parse_args()
+
+    with ECDIterator(
+        args.root,
+        args.sequence,
+        load_imu=False,
+        load_gt_pose=False,
+        depth_load_mode=False,
+    ) as iterator:
+        stream = itertools.islice(iterator, MAX_SAMPLES)
+        timestamps = []
+        event_counts = []
+        preview_image = None
+        preview_count = -1
+        for sample in stream:
+            timestamps.append(sample["timestamp"])
+            event_count = len(sample["events"])
+            event_counts.append(event_count)
+            if event_count > preview_count and sample["image"] is not None:
+                preview_image = sample["image"]
+                preview_count = event_count
+        if not event_counts:
+            raise RuntimeError("The ECD sequence has no frame intervals.")
+        if preview_image is None:
+            raise RuntimeError("The ECD sequence does not contain images.")
+
+        print(f"{iterator.sequence}: inspected {len(event_counts):,} frame intervals")
+        print(f"events per interval: min={min(event_counts):,} max={max(event_counts):,}")
+
+    relative_time = np.asarray(timestamps, dtype=np.float64)
+    relative_time -= relative_time[0]
+
+    fig, (count_axis, image_axis) = plt.subplots(1, 2, figsize=(10.5, 3.8))
+    count_axis.plot(relative_time, event_counts, linewidth=1.0, marker=".", markersize=2)
+    count_axis.set_xlabel("time from first interval (s)")
+    count_axis.set_ylabel("events per interval")
+    count_axis.set_title(f"{args.sequence} event activity")
+    count_axis.grid(alpha=0.3)
+    image_axis.imshow(preview_image, cmap="gray")
+    image_axis.set_title(f"image at highest-activity interval ({preview_count:,} events)")
+    image_axis.axis("off")
+
+    fig.tight_layout()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.output, dpi=140)
+    plt.close(fig)
+    print(f"saved {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/readers/ecd_event_count_image.py
+++ b/examples/readers/ecd_event_count_image.py
@@ -1,0 +1,88 @@
+r"""Visualize a fixed-count ECD event packet and event-count image.
+
+Run:
+    python examples/readers/ecd_event_count_image.py \
+        /data/ECD/datasets/davis/shapes_rotation
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from evlib.dataloaders import DavisRecordingLoader
+from evlib.representation import Histogram
+from evlib.vis.view2d import events as render_events
+
+
+NUM_EVENTS = 30_000
+OUTPUT_PATH = Path("outputs/ecd_event_count_image.png")
+
+
+def get_args_parser() -> argparse.ArgumentParser:
+    """Create the argument parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("recording", help="ECD/DAVIS recording directory.")
+    parser.add_argument(
+        "--sensor-resolution",
+        type=int,
+        nargs=2,
+        metavar=("HEIGHT", "WIDTH"),
+        help="Sensor size for recordings without frames.",
+    )
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH, help="Figure output path.")
+    return parser
+
+
+def main() -> None:
+    """Run the ECD event-count-image example."""
+    args = get_args_parser().parse_args()
+    requested_resolution = None if args.sensor_resolution is None else tuple(args.sensor_resolution)
+
+    with DavisRecordingLoader(
+        args.recording,
+        depth_load_mode=False,
+        sensor_resolution=requested_resolution,
+    ) as reader:
+        sensor_resolution = reader.sensor_resolution
+        if sensor_resolution is None:
+            raise RuntimeError(
+                "The recording has no frames to infer the sensor size from. "
+                "Pass --sensor-resolution HEIGHT WIDTH."
+            )
+
+        events = reader.load_events(0, min(NUM_EVENTS, reader.num_events))
+        if len(events) == 0:
+            raise RuntimeError("The event window is empty.")
+
+        start = float(events.timestamp[0])
+        end = float(events.timestamp[-1])
+        count_image = Histogram(sensor_resolution, use_polarity=False)(events.as_numpy())
+
+        print(
+            f"{reader.sequence}: {len(events):,} of {reader.num_events:,} events "
+            f"over {end - start:.6f} seconds"
+        )
+
+        fig, (events_axis, count_axis) = plt.subplots(1, 2, figsize=(9.5, 3.8))
+        events_axis.imshow(render_events(events.as_numpy(), sensor_resolution))
+        events_axis.set_title(f"{len(events):,} events")
+        count_axis.imshow(count_image, cmap="magma")
+        count_axis.set_title("event count image")
+        for axis in (events_axis, count_axis):
+            axis.axis("off")
+
+        fig.tight_layout()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(args.output, dpi=140)
+        plt.close(fig)
+        print(f"saved {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/readers/mvsec_event_windows.py
+++ b/examples/readers/mvsec_event_windows.py
@@ -1,0 +1,101 @@
+r"""Compare fixed-count and flow-aligned MVSEC event windows.
+
+Run:
+    python examples/readers/mvsec_event_windows.py \
+        /data/MVSEC/indoor_flying indoor_flying1
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from evlib.dataloaders import MVSECDataLoader
+from evlib.vis.view2d import events as render_events
+from evlib.vis.view2d import optical_flow as render_flow
+
+
+NUM_EVENTS = 30_000
+OUTPUT_PATH = Path("outputs/mvsec_event_windows.png")
+
+
+def get_args_parser() -> argparse.ArgumentParser:
+    """Create the argument parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("root", help="MVSEC dataset root.")
+    parser.add_argument("sequence", help="MVSEC sequence name.")
+    parser.add_argument("--output", type=Path, default=OUTPUT_PATH, help="Figure output path.")
+    return parser
+
+
+def main() -> None:
+    """Run the MVSEC event-window example."""
+    args = get_args_parser().parse_args()
+
+    with MVSECDataLoader(
+        args.root,
+        args.sequence,
+        camera="left",
+        event_load_mode="lazy",
+        image_load_mode="lazy",
+        load_gt_flow_hdf5="lazy",
+    ) as reader:
+        flow_timestamps = reader.gt_flow_hdf5_timestamps
+        if flow_timestamps is None or len(flow_timestamps) < 2:
+            raise RuntimeError("The MVSEC sequence does not contain ground-truth flow.")
+
+        flow_index = (len(flow_timestamps) - 1) // 2
+        start = float(flow_timestamps[flow_index])
+        end = float(flow_timestamps[flow_index + 1])
+        window_duration = end - start
+
+        packet_start = max(reader.time_to_index(start) + 1, 0)
+        packet_end = min(packet_start + NUM_EVENTS, reader.num_events)
+        event_packet = reader.load_events(packet_start, packet_end)
+        if len(event_packet) == 0:
+            raise RuntimeError("The MVSEC sequence does not contain events.")
+        packet_duration = float(event_packet.timestamp[-1] - event_packet.timestamp[0])
+
+        time_window = reader.get_events_by_time(start, end)
+        if len(time_window) == 0:
+            raise RuntimeError("The MVSEC flow interval contains no events.")
+
+        flow = reader.load_flow_hdf5(flow_index)
+        if flow is None:
+            raise RuntimeError("The MVSEC flow interval could not be loaded.")
+
+        print(
+            f"{reader.sequence} ({reader.camera}): {len(event_packet):,} events over "
+            f"{packet_duration:.6f} seconds; {len(time_window):,} events over "
+            f"the {window_duration * 1e3:.0f} ms ground-truth flow interval"
+        )
+
+        count_image = render_events(event_packet.as_numpy(), reader.IMAGE_SHAPE)
+        time_image = render_events(time_window.as_numpy(), reader.IMAGE_SHAPE)
+        flow_image, _ = render_flow(flow[1], flow[0], visualize_color_wheel=False)
+
+        fig, (count_axis, time_axis, flow_axis) = plt.subplots(1, 3, figsize=(13.5, 3.8))
+        count_axis.imshow(count_image)
+        count_axis.set_title(f"fixed count: {len(event_packet):,}\n{packet_duration * 1e3:.0f} ms")
+        time_axis.imshow(time_image)
+        time_axis.set_title(
+            f"flow interval: {window_duration * 1e3:.0f} ms\n{len(time_window):,} events"
+        )
+        flow_axis.imshow(flow_image)
+        flow_axis.set_title("ground-truth optical flow")
+        for axis in (count_axis, time_axis, flow_axis):
+            axis.axis("off")
+        fig.tight_layout(rect=(0, 0, 1, 0.94))
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(args.output, dpi=140)
+        plt.close(fig)
+        print(f"saved {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/examples/__init__.py
+++ b/tests/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the example scripts."""

--- a/tests/examples/test_example_scripts.py
+++ b/tests/examples/test_example_scripts.py
@@ -1,0 +1,159 @@
+"""Tests for the public example scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess  # noqa: S404
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+import matplotlib
+import pytest
+
+from tests.dataloaders.test_davis import _make_davis_recording
+from tests.dataloaders.test_dsec import SEQ as DSEC_SEQUENCE
+from tests.dataloaders.test_dsec import _build_cleaned_dsec_tree
+from tests.dataloaders.test_mvsec import SEQ as MVSEC_SEQUENCE
+from tests.dataloaders.test_mvsec import _make_gt_hdf5
+from tests.dataloaders.test_mvsec import _make_hdf5
+from tests.datasets.test_ecd import _write_sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ECD_SEQUENCE = "shapes_rotation"
+
+
+@pytest.fixture(autouse=True)
+def example_environment(  # noqa: D103
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    matplotlib.use("Agg")
+    yield
+
+
+def _load_example(script: str) -> ModuleType:
+    path = REPO_ROOT / script
+    spec = importlib.util.spec_from_file_location(f"example_{path.stem}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_example(monkeypatch: pytest.MonkeyPatch, script: str, *argv: str) -> None:
+    module = _load_example(script)
+    monkeypatch.setattr(sys, "argv", [script, *argv])
+    module.main()
+
+
+def _run_example_process(cache_dir: Path, script: str, *argv: str) -> None:
+    environment = dict(os.environ, MPLBACKEND="Agg", XDG_CACHE_HOME=str(cache_dir))
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(REPO_ROOT / script), *argv],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=environment,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _dsec_root(tmp_path: Path) -> str:
+    _build_cleaned_dsec_tree(tmp_path)
+    return str(tmp_path)
+
+
+def _mvsec_root(tmp_path: Path) -> str:
+    _make_hdf5(tmp_path / f"{MVSEC_SEQUENCE}_data.hdf5")
+    _make_gt_hdf5(tmp_path / f"{MVSEC_SEQUENCE}_gt.hdf5")
+    return str(tmp_path)
+
+
+class TestDSECExamples:  # noqa: D101
+    def test_flow_batch_example_runs_with_worker_processes(  # noqa: D102
+        self, tmp_path: Path
+    ) -> None:
+        root = _dsec_root(tmp_path)
+        output = tmp_path / "dsec_flow_batch.png"
+
+        _run_example_process(
+            tmp_path / "cache",
+            "examples/datasets/dsec_flow_batch.py",
+            root,
+            DSEC_SEQUENCE,
+            "--output",
+            str(output),
+        )
+
+        assert output.is_file()
+
+
+class TestMVSECExamples:  # noqa: D101
+    def test_event_windows_and_flow_example_writes_a_figure(  # noqa: D102
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = _mvsec_root(tmp_path)
+        output = tmp_path / "mvsec_event_windows.png"
+
+        _run_example(
+            monkeypatch,
+            "examples/readers/mvsec_event_windows.py",
+            root,
+            MVSEC_SEQUENCE,
+            "--output",
+            str(output),
+        )
+
+        assert output.is_file()
+
+
+class TestECDExamples:  # noqa: D101
+    def test_frame_activity_example_writes_a_figure(  # noqa: D102
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_sequence(tmp_path, ECD_SEQUENCE)
+        output = tmp_path / "ecd_frame_activity.png"
+
+        _run_example(
+            monkeypatch,
+            "examples/datasets/ecd_frame_activity.py",
+            str(tmp_path),
+            ECD_SEQUENCE,
+            "--output",
+            str(output),
+        )
+
+        assert "inspected 3 frame intervals" in capsys.readouterr().out
+        assert output.is_file()
+
+    def test_event_count_image_accepts_an_explicit_resolution(  # noqa: D102
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        recording = tmp_path / "recording"
+        _make_davis_recording(recording)
+        output = tmp_path / "ecd_event_count_image.png"
+
+        _run_example(
+            monkeypatch,
+            "examples/readers/ecd_event_count_image.py",
+            str(recording),
+            "--sensor-resolution",
+            "180",
+            "240",
+            "--output",
+            str(output),
+        )
+
+        assert output.is_file()


### PR DESCRIPTION
Adds `docs/data_loading.md`, explaining when to use evlib datasets, low-level readers, and PyTorch
  batching, plus four runnable examples:

  - `examples/datasets/dsec_flow_batch.py`: demonstrates `DSECDataset` with PyTorch `DataLoader`
  batching for events, images, and optical flow.
  - `examples/readers/mvsec_event_windows.py`: demonstrates `MVSECDataLoader` for loading fixed count
  and flow aligned event windows alongside ground truth optical flow.
  - `examples/datasets/ecd_frame_activity.py`: demonstrates `ECDIterator` for sequential access and
  plotting event activity across frame intervals.
  - `examples/readers/ecd_event_count_image.py`: demonstrates `DavisRecordingLoader` for loading a
  fixed count event packet and creating an event count image.

  Each example saves a figure for visual inspection. 

`tests/examples/test_example_scripts.py` includes tests using synthetic recordings